### PR TITLE
Add Unit Tests

### DIFF
--- a/BlazorShop.Tests/Application/Services/ProductServiceTests.cs
+++ b/BlazorShop.Tests/Application/Services/ProductServiceTests.cs
@@ -1,0 +1,268 @@
+﻿namespace BlazorShop.Tests.Application.Services
+{
+    using AutoMapper;
+
+    using BlazorShop.Application.DTOs.Product;
+    using BlazorShop.Application.Services;
+    using BlazorShop.Domain.Contracts;
+    using BlazorShop.Domain.Entities;
+
+    using Moq;
+
+    using Xunit;
+
+    public class ProductServiceTests
+    {
+        private readonly Mock<IGenericRepository<Product>> _mockProductRepository;
+        private readonly Mock<IMapper> _mockMapper;
+        private readonly ProductService _productService;
+
+        public ProductServiceTests()
+        {
+            // Moq init
+            this._mockProductRepository = new Mock<IGenericRepository<Product>>();
+            this._mockMapper = new Mock<IMapper>();
+
+            // Create service
+            this._productService = new ProductService(this._mockProductRepository.Object, this._mockMapper.Object);
+        }
+
+        [Fact]
+        public async Task GetAllAsync_WhenProductsExist_ShouldReturnMappedProducts()
+        {
+            // Arrange
+            var products = new List<Product>
+            {
+                new Product { Id = Guid.NewGuid(), Name = "Product1" },
+                new Product { Id = Guid.NewGuid(), Name = "Product2" }
+            };
+
+            var mappedProducts = new List<GetProduct>
+            {
+                new GetProduct { Id = products[0].Id, Name = "Product1" },
+                new GetProduct { Id = products[1].Id, Name = "Product2" }
+            };
+
+            // Moq config
+            this._mockProductRepository.Setup(repo => repo.GetAllAsync())
+                                  .ReturnsAsync(products);
+
+            this._mockMapper.Setup(mapper => mapper.Map<IEnumerable<GetProduct>>(products))
+                       .Returns(mappedProducts);
+
+            // Act
+            var result = await this._productService.GetAllAsync();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(mappedProducts, result);
+            this._mockProductRepository.Verify(repo => repo.GetAllAsync(), Times.Once);
+            this._mockMapper.Verify(mapper => mapper.Map<IEnumerable<GetProduct>>(products), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllAsync_WhenNoProductsExist_ShouldReturnEmptyList()
+        {
+            // Arrange
+            var products = new List<Product>();
+
+            this._mockProductRepository.Setup(repo => repo.GetAllAsync())
+                                  .ReturnsAsync(products);
+
+            this._mockMapper.Setup(mapper => mapper.Map<IEnumerable<GetProduct>>(products))
+                       .Returns(new List<GetProduct>());
+
+            // Act
+            var result = await this._productService.GetAllAsync();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Empty(result);
+            this._mockProductRepository.Verify(repo => repo.GetAllAsync(), Times.Once);
+            this._mockMapper.Verify(mapper => mapper.Map<IEnumerable<GetProduct>>(products), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_WhenProductExists_ShouldReturnMappedProduct()
+        {
+            // Arrange
+            var productId = Guid.NewGuid();
+            var product = new Product { Id = productId, Name = "Product1" };
+            var mappedProduct = new GetProduct { Id = productId, Name = "Product1" };
+            this._mockProductRepository.Setup(repo => repo.GetByIdAsync(productId))
+                                  .ReturnsAsync(product);
+            this._mockMapper.Setup(mapper => mapper.Map<GetProduct>(product))
+                       .Returns(mappedProduct);
+
+            // Act
+            var result = await this._productService.GetByIdAsync(productId);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(mappedProduct, result);
+            this._mockProductRepository.Verify(repo => repo.GetByIdAsync(productId), Times.Once);
+            this._mockMapper.Verify(mapper => mapper.Map<GetProduct>(product), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_WhenProductDoesNotExist_ShouldReturnEmptyProduct()
+        {
+            // Arrange
+            var productId = Guid.NewGuid();
+            this._mockProductRepository.Setup(repo => repo.GetByIdAsync(productId))
+                                  .ReturnsAsync((Product)null);
+
+            // Act
+            var result = await this._productService.GetByIdAsync(productId);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(default, result.Id);
+            Assert.Null(result.Name);
+            this._mockProductRepository.Verify(repo => repo.GetByIdAsync(productId), Times.Once);
+            this._mockMapper.Verify(mapper => mapper.Map<GetProduct>(It.IsAny<Product>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task AddAsync_WhenProductIsAdded_ShouldReturnSuccessResponse()
+        {
+            // Arrange
+            var product = new CreateProduct { Name = "Product1" };
+            var mappedProduct = new Product { Name = "Product1" };
+            this._mockMapper.Setup(mapper => mapper.Map<Product>(product))
+                       .Returns(mappedProduct);
+            this._mockProductRepository.Setup(repo => repo.AddAsync(mappedProduct))
+                                  .ReturnsAsync(1);
+
+            // Act
+            var result = await this._productService.AddAsync(product);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.True(result.Success);
+            Assert.Equal("Product added successfully", result.Message);
+            this._mockMapper.Verify(mapper => mapper.Map<Product>(product), Times.Once);
+            this._mockProductRepository.Verify(repo => repo.AddAsync(mappedProduct), Times.Once);
+        }
+
+        [Fact]
+        public async Task AddAsync_WhenProductIsNotAdded_ShouldReturnFailureResponse()
+        {
+            // Arrange
+            var product = new CreateProduct { Name = "Product1" };
+            var mappedProduct = new Product { Name = "Product1" };
+            this._mockMapper.Setup(mapper => mapper.Map<Product>(product))
+                       .Returns(mappedProduct);
+            this._mockProductRepository.Setup(repo => repo.AddAsync(mappedProduct))
+                                  .ReturnsAsync(0);
+
+            // Act
+            var result = await this._productService.AddAsync(product);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.False(result.Success);
+            Assert.Equal("Product not added", result.Message);
+            this._mockMapper.Verify(mapper => mapper.Map<Product>(product), Times.Once);
+            this._mockProductRepository.Verify(repo => repo.AddAsync(mappedProduct), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_WhenProductIsUpdated_ShouldReturnSuccessResponse()
+        {
+            // Arrange
+            var product = new UpdateProduct { Id = Guid.NewGuid(), Name = "Product1" };
+            var mappedProduct = new Product { Id = product.Id, Name = "Product1" };
+            this._mockMapper.Setup(mapper => mapper.Map<Product>(product))
+                       .Returns(mappedProduct);
+            this._mockProductRepository.Setup(repo => repo.UpdateAsync(mappedProduct))
+                                  .ReturnsAsync(1);
+
+            // Act
+            var result = await this._productService.UpdateAsync(product);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.True(result.Success);
+            Assert.Equal("Product updated successfully", result.Message);
+            this._mockMapper.Verify(mapper => mapper.Map<Product>(product), Times.Once);
+            this._mockProductRepository.Verify(repo => repo.UpdateAsync(mappedProduct), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_WhenProductIsNotUpdated_ShouldReturnFailureResponse()
+        {
+            // Arrange
+            var product = new UpdateProduct { Id = Guid.NewGuid(), Name = "Product1" };
+            var mappedProduct = new Product { Id = product.Id, Name = "Product1" };
+            this._mockMapper.Setup(mapper => mapper.Map<Product>(product))
+                       .Returns(mappedProduct);
+            this._mockProductRepository.Setup(repo => repo.UpdateAsync(mappedProduct))
+                                  .ReturnsAsync(0);
+
+            // Act
+            var result = await this._productService.UpdateAsync(product);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.False(result.Success);
+            Assert.Equal("Product not found", result.Message);
+            this._mockMapper.Verify(mapper => mapper.Map<Product>(product), Times.Once);
+            this._mockProductRepository.Verify(repo => repo.UpdateAsync(mappedProduct), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_WhenProductIsDeleted_ShouldReturnSuccessResponse()
+        {
+            // Arrange
+            var productId = Guid.NewGuid();
+            this._mockProductRepository.Setup(repo => repo.DeleteAsync(productId))
+                                  .ReturnsAsync(1);
+
+            // Act
+            var result = await this._productService.DeleteAsync(productId);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.True(result.Success);
+            Assert.Equal("Product deleted successfully", result.Message);
+            this._mockProductRepository.Verify(repo => repo.DeleteAsync(productId), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_WhenProductIsNotDeleted_ShouldReturnFailureResponse()
+        {
+            // Arrange
+            var productId = Guid.NewGuid();
+            this._mockProductRepository.Setup(repo => repo.DeleteAsync(productId))
+                                  .ReturnsAsync(0);
+
+            // Act
+            var result = await this._productService.DeleteAsync(productId);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.False(result.Success);
+            Assert.Equal("Product not found", result.Message);
+            this._mockProductRepository.Verify(repo => repo.DeleteAsync(productId), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_WhenProductDoesNotExist_ShouldReturnFailureResponse()
+        {
+            // Arrange
+            var productId = Guid.NewGuid();
+            this._mockProductRepository.Setup(repo => repo.DeleteAsync(productId))
+                                  .ReturnsAsync(-1);
+
+            // Act
+            var result = await this._productService.DeleteAsync(productId);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.False(result.Success);
+            Assert.Equal("Product not found", result.Message);
+            this._mockProductRepository.Verify(repo => repo.DeleteAsync(productId), Times.Once);
+        }
+    }
+}

--- a/BlazorShop.Tests/BlazorShop.Tests.csproj
+++ b/BlazorShop.Tests/BlazorShop.Tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Application\Services\Authentication\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BlazorShop.Application\BlazorShop.Application.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/BlazorShop.sln
+++ b/BlazorShop.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorShop.Web", "BlazorSho
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorShop.Web.Shared", "BlazorShop.Presentation\BlazorShop.Web.Shared\BlazorShop.Web.Shared.csproj", "{AFE32812-DCE4-592A-1B72-5F8A9F560F2E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorShop.Tests", "BlazorShop.Tests\BlazorShop.Tests.csproj", "{FECE84AC-01C9-4F82-9EDA-DD56713E574A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,6 +49,10 @@ Global
 		{AFE32812-DCE4-592A-1B72-5F8A9F560F2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AFE32812-DCE4-592A-1B72-5F8A9F560F2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AFE32812-DCE4-592A-1B72-5F8A9F560F2E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FECE84AC-01C9-4F82-9EDA-DD56713E574A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FECE84AC-01C9-4F82-9EDA-DD56713E574A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FECE84AC-01C9-4F82-9EDA-DD56713E574A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FECE84AC-01C9-4F82-9EDA-DD56713E574A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
#### PR Classification
Add unit tests for the `ProductService` class to improve test coverage.

#### PR Summary
This pull request introduces unit tests for the `ProductService` class, enhancing the testing framework of the application. 
- `ProductServiceTests.cs`: Added comprehensive unit tests for various `ProductService` methods including retrieval, addition, updating, and deletion of products.
- `BlazorShop.Tests.csproj`: Updated to include necessary package references for testing, such as `Moq` and `xunit`, and set the target framework to `.NET 9.0`.
- `BlazorShop.sln`: Modified to include the `BlazorShop.Tests` project in the solution.
