### PR TITLE
Update dependencies and improve DI configuration

### DIFF
--- a/BlazorShop.Application/BlazorShop.Application.csproj
+++ b/BlazorShop.Application/BlazorShop.Application.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="16.0.0" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />

--- a/BlazorShop.Application/DependencyInjection.cs
+++ b/BlazorShop.Application/DependencyInjection.cs
@@ -12,6 +12,7 @@
     using BlazorShop.Application.Validations.Authentication;
 
     using FluentValidation;
+    using FluentValidation.AspNetCore;
 
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
@@ -20,15 +21,15 @@
     {
         public static IServiceCollection AddApplication(this IServiceCollection services, IConfiguration configuration)
         {
-            services.AddAutoMapper(cfg => cfg.AddProfile<MappingConfig>());
+            services.AddAutoMapper(typeof(MappingConfig));
             services.AddScoped<IProductService, ProductService>();
             services.AddScoped<ICategoryService, CategoryService>();
             services.AddScoped<IProductVariantService, ProductVariantService>();
             services.AddScoped<IProductRecommendationService, ProductRecommendationService>();
-            services.AddScoped<IMetricsService, MetricsService>();
 
             services.Configure<RecommendationOptions>(configuration.GetSection(RecommendationOptions.SectionName));
 
+            services.AddFluentValidationAutoValidation();
             services.AddValidatorsFromAssemblyContaining<CreateUserValidator>();
             services.AddScoped<IValidationService, ValidationService>();
             services.AddScoped<IAuthenticationService, AuthenticationService>();

--- a/BlazorShop.Infrastructure/BlazorShop.Infrastructure.csproj
+++ b/BlazorShop.Infrastructure/BlazorShop.Infrastructure.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
-    <PackageReference Include="MimeKit" Version="4.14.0" />
+    <PackageReference Include="MimeKit" Version="4.15.1" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />


### PR DESCRIPTION
Update dependencies and improve DI configuration

- Bump AutoMapper to 16.1.1 and MimeKit to 4.15.1
- Switch AutoMapper registration to use typeof(MappingConfig)
- Add FluentValidation.AspNetCore and enable auto-validation
- Register validators from CreateUserValidator assembly
- Remove IMetricsService registration from DI