### PR TITLE
Centralize client app URL config, update token refresh API

### DIFF
--- a/BlazorShop.Application/DependencyInjection.cs
+++ b/BlazorShop.Application/DependencyInjection.cs
@@ -12,7 +12,6 @@
     using BlazorShop.Application.Validations.Authentication;
 
     using FluentValidation;
-    using FluentValidation.AspNetCore;
 
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
@@ -21,15 +20,15 @@
     {
         public static IServiceCollection AddApplication(this IServiceCollection services, IConfiguration configuration)
         {
-            services.AddAutoMapper(typeof(MappingConfig));
+            services.AddAutoMapper(cfg => cfg.AddProfile<MappingConfig>());
             services.AddScoped<IProductService, ProductService>();
             services.AddScoped<ICategoryService, CategoryService>();
             services.AddScoped<IProductVariantService, ProductVariantService>();
             services.AddScoped<IProductRecommendationService, ProductRecommendationService>();
 
             services.Configure<RecommendationOptions>(configuration.GetSection(RecommendationOptions.SectionName));
+            services.Configure<ClientAppOptions>(configuration.GetSection(ClientAppOptions.SectionName));
 
-            services.AddFluentValidationAutoValidation();
             services.AddValidatorsFromAssemblyContaining<CreateUserValidator>();
             services.AddScoped<IValidationService, ValidationService>();
             services.AddScoped<IAuthenticationService, AuthenticationService>();

--- a/BlazorShop.Application/Options/ClientAppOptions.cs
+++ b/BlazorShop.Application/Options/ClientAppOptions.cs
@@ -1,0 +1,9 @@
+namespace BlazorShop.Application.Options
+{
+    public class ClientAppOptions
+    {
+        public const string SectionName = "ClientApp";
+
+        public string BaseUrl { get; set; } = "https://localhost:7258";
+    }
+}

--- a/BlazorShop.Application/Services/Authentication/AuthenticationService.cs
+++ b/BlazorShop.Application/Services/Authentication/AuthenticationService.cs
@@ -4,6 +4,7 @@
 
     using BlazorShop.Application.DTOs;
     using BlazorShop.Application.DTOs.UserIdentity;
+    using BlazorShop.Application.Options;
     using BlazorShop.Application.Services.Contracts.Authentication;
     using BlazorShop.Application.Services.Contracts.Logging;
     using BlazorShop.Application.Validations;
@@ -12,6 +13,8 @@
     using BlazorShop.Domain.Entities.Identity;
 
     using FluentValidation;
+
+    using Microsoft.Extensions.Options;
 
     public class AuthenticationService : IAuthenticationService
     {
@@ -25,6 +28,7 @@
         private readonly IValidator<ChangePassword> _changePasswordValidator;
         private readonly IValidationService _validationService;
         private readonly IEmailService _emailService;
+        private readonly ClientAppOptions _clientAppOptions;
 
         public AuthenticationService(
             IAppTokenManager tokenManager,
@@ -36,7 +40,8 @@
             IValidator<LoginUser> loginUserValidator,
             IValidationService validationService,
             IValidator<ChangePassword> changePasswordValidator,
-            IEmailService emailService)
+            IEmailService emailService,
+            IOptions<ClientAppOptions>? clientAppOptions = null)
         {
             _tokenManager = tokenManager;
             _userManager = userManager;
@@ -48,6 +53,7 @@
             _validationService = validationService;
             _changePasswordValidator = changePasswordValidator;
             _emailService = emailService;
+            _clientAppOptions = clientAppOptions?.Value ?? new ClientAppOptions();
         }
 
         public async Task<ServiceResponse> CreateUser(CreateUser user)
@@ -78,7 +84,7 @@
             try
             {
                 var token = await _userManager.GenerateEmailConfirmationTokenAsync(mappedUser);
-                var confirmationLink = $"https://localhost:7258/confirm-email?userId={mappedUser.Id}&token={Uri.EscapeDataString(token)}";
+                var confirmationLink = this.BuildClientUrl($"confirm-email?userId={mappedUser.Id}&token={Uri.EscapeDataString(token)}");
 
                 await this.SendConfirmationEmail(user.Email,
                     $"Please confirm your email by clicking <a href=\"{confirmationLink}\">here</a>.");
@@ -151,7 +157,7 @@
             if (!currentUser.EmailConfirmed)
             {
                 var token = await _userManager.GenerateEmailConfirmationTokenAsync(currentUser);
-                var confirmationLink = $"https://localhost:7258/confirm-email?userId={currentUser.Id}&token={Uri.EscapeDataString(token)}";
+                var confirmationLink = this.BuildClientUrl($"confirm-email?userId={currentUser.Id}&token={Uri.EscapeDataString(token)}");
 
                 var pendingEmail = currentUser.Email;
                 if (!string.IsNullOrWhiteSpace(pendingEmail))
@@ -181,14 +187,9 @@
             var accessToken = _tokenManager.GenerateAccessToken(claims);
             var refreshToken = _tokenManager.GetReFreshToken();
 
-            var saveTokenResult = 0;
-            var isRefreshTokenValid = await _tokenManager.ValidateRefreshTokenAsync(refreshToken);
+            var saveTokenResult = await _tokenManager.UpdateRefreshTokenAsync(currentUser.Id, refreshToken);
 
-            if (isRefreshTokenValid)
-            {
-                saveTokenResult = await _tokenManager.UpdateRefreshTokenAsync(currentUser.Id, refreshToken);
-            }
-            else
+            if (saveTokenResult <= 0)
             {
                 saveTokenResult = await _tokenManager.AddRefreshTokenAsync(currentUser.Id, refreshToken);
             }
@@ -224,9 +225,17 @@
             var claims = await _userManager.GetUserClaimsAsync(currentUser.Email);
             var newAccessToken = _tokenManager.GenerateAccessToken(claims);
             var newRefreshToken = _tokenManager.GetReFreshToken();
-            //var saveTokenResult = await _tokenManager.UpdateRefreshTokenAsync(userId, newRefreshToken);
 
-            return new LoginResponse { Success = true, Message = "Token revived successfully.", Token = newAccessToken, RefreshToken = newRefreshToken };
+            var saveTokenResult = await _tokenManager.UpdateRefreshTokenAsync(userId, newRefreshToken);
+
+            if (saveTokenResult <= 0)
+            {
+                saveTokenResult = await _tokenManager.AddRefreshTokenAsync(userId, newRefreshToken);
+            }
+
+            return saveTokenResult <= 0
+                ? new LoginResponse { Message = "Error occurred in login." }
+                : new LoginResponse { Success = true, Message = "Token revived successfully.", Token = newAccessToken, RefreshToken = newRefreshToken };
         }
 
         public async Task<ServiceResponse> ChangePassword(ChangePassword changePasswordDto, string userId)
@@ -299,6 +308,18 @@
             return ok
                 ? new ServiceResponse(true, "Profile updated successfully.")
                 : new ServiceResponse(false, "Failed to update profile.");
+        }
+
+        private string BuildClientUrl(string pathAndQuery)
+        {
+            var baseUrl = _clientAppOptions.BaseUrl;
+
+            if (string.IsNullOrWhiteSpace(baseUrl))
+            {
+                baseUrl = "https://localhost:7258";
+            }
+
+            return $"{baseUrl.TrimEnd('/')}/{pathAndQuery.TrimStart('/')}";
         }
     }
 }

--- a/BlazorShop.Infrastructure/Repositories/Authentication/AppTokenManager.cs
+++ b/BlazorShop.Infrastructure/Repositories/Authentication/AppTokenManager.cs
@@ -57,11 +57,19 @@
         {
             var result = await _context.RefreshTokens.FirstOrDefaultAsync(_ => _.Token == refreshToken);
 
-            return result!.UserId!;
+            return result?.UserId ?? string.Empty;
         }
 
         public async Task<int> AddRefreshTokenAsync(string userId, string refreshToken)
         {
+            var existingToken = await _context.RefreshTokens.FirstOrDefaultAsync(_ => _.UserId == userId);
+
+            if (existingToken is not null)
+            {
+                existingToken.Token = refreshToken;
+                return await _context.SaveChangesAsync();
+            }
+
             _context.RefreshTokens.Add(new RefreshToken
             {
                 UserId = userId,
@@ -73,7 +81,7 @@
 
         public async Task<int> UpdateRefreshTokenAsync(string userId, string refreshToken)
         {
-            var user = await _context.RefreshTokens.FirstOrDefaultAsync(_ => _.Token == refreshToken);
+            var user = await _context.RefreshTokens.FirstOrDefaultAsync(_ => _.UserId == userId);
 
             if (user is null)
             {

--- a/BlazorShop.Infrastructure/Services/StripePaymentService.cs
+++ b/BlazorShop.Infrastructure/Services/StripePaymentService.cs
@@ -2,13 +2,23 @@
 {
     using BlazorShop.Application.DTOs;
     using BlazorShop.Application.DTOs.Payment;
+    using BlazorShop.Application.Options;
     using BlazorShop.Application.Services.Contracts.Payment;
     using BlazorShop.Domain.Entities;
+
+    using Microsoft.Extensions.Options;
 
     using Stripe.Checkout;
 
     public class StripePaymentService : IPaymentService
     {
+        private readonly ClientAppOptions _clientAppOptions;
+
+        public StripePaymentService(IOptions<ClientAppOptions>? clientAppOptions = null)
+        {
+            _clientAppOptions = clientAppOptions?.Value ?? new ClientAppOptions();
+        }
+
         public async Task<ServiceResponse> Pay(decimal totalAmount, IEnumerable<Product> cartProducts, IEnumerable<ProcessCart> carts)
         {
             try
@@ -41,8 +51,8 @@
                     PaymentMethodTypes = ["card"],
                     LineItems = lineItems,
                     Mode = "payment",
-                    SuccessUrl = "https://localhost:7258/payment-success",
-                    CancelUrl = "https://localhost:7258/payment-cancel",
+                    SuccessUrl = this.BuildClientUrl("payment-success"),
+                    CancelUrl = this.BuildClientUrl("payment-cancel"),
                 };
 
                 var service = new SessionService();
@@ -54,6 +64,18 @@
             {
                 return new ServiceResponse(false, ex.Message);
             }
+        }
+
+        private string BuildClientUrl(string path)
+        {
+            var baseUrl = _clientAppOptions.BaseUrl;
+
+            if (string.IsNullOrWhiteSpace(baseUrl))
+            {
+                baseUrl = "https://localhost:7258";
+            }
+
+            return $"{baseUrl.TrimEnd('/')}/{path.TrimStart('/')}";
         }
     }
 }

--- a/BlazorShop.Presentation/BlazorShop.API/Controllers/AuthenticationController.cs
+++ b/BlazorShop.Presentation/BlazorShop.API/Controllers/AuthenticationController.cs
@@ -1,7 +1,6 @@
 ﻿namespace BlazorShop.API.Controllers
 {
     using System.Security.Claims;
-    using System.Web;
 
     using BlazorShop.Application.DTOs.UserIdentity;
     using BlazorShop.Application.Services.Contracts.Authentication;
@@ -49,11 +48,10 @@
         /// </summary>
         /// <param name="refreshToken">The refresh token </param>
         /// <returns>The result of the refresh </returns>
-        [HttpGet("refreshToken/{refreshToken}")]
-        public async Task<IActionResult> RefreshToken(string refreshToken)
+        [HttpPost("refresh-token")]
+        public async Task<IActionResult> RefreshToken([FromBody] string refreshToken)
         {
-            var encodedRefreshToken = HttpUtility.UrlDecode(refreshToken);
-            var result = await _authenticationService.ReviveToken(encodedRefreshToken);
+            var result = await _authenticationService.ReviveToken(refreshToken);
             return result.Success ? this.Ok(result) : this.BadRequest(result);
         }
 

--- a/BlazorShop.Presentation/BlazorShop.API/Controllers/PaymentController.cs
+++ b/BlazorShop.Presentation/BlazorShop.API/Controllers/PaymentController.cs
@@ -1,7 +1,10 @@
 ﻿namespace BlazorShop.API.Controllers
 {
     using BlazorShop.Application.DTOs.Payment;
+    using BlazorShop.Application.Options;
     using BlazorShop.Application.Services.Contracts.Payment;
+
+    using Microsoft.Extensions.Options;
 
     using Microsoft.AspNetCore.Mvc;
 
@@ -11,11 +14,16 @@
     {
         private readonly IPaymentMethodService _paymentMethodService;
         private readonly IPayPalPaymentService _payPalPaymentService;
+        private readonly ClientAppOptions _clientAppOptions;
 
-        public PaymentController(IPaymentMethodService paymentMethodService, IPayPalPaymentService payPalPaymentService)
+        public PaymentController(
+            IPaymentMethodService paymentMethodService,
+            IPayPalPaymentService payPalPaymentService,
+            IOptions<ClientAppOptions>? clientAppOptions = null)
         {
             _paymentMethodService = paymentMethodService;
             _payPalPaymentService = payPalPaymentService;
+            _clientAppOptions = clientAppOptions?.Value ?? new ClientAppOptions();
         }
 
         /// <summary>
@@ -39,7 +47,19 @@
             var ok = await _payPalPaymentService.CaptureAsync(token);
             if (!ok) return BadRequest("Capture failed");
 
-            return Redirect("https://localhost:7258/payment-success");
+            return Redirect(this.BuildClientUrl("payment-success"));
+        }
+
+        private string BuildClientUrl(string path)
+        {
+            var baseUrl = _clientAppOptions.BaseUrl;
+
+            if (string.IsNullOrWhiteSpace(baseUrl))
+            {
+                baseUrl = "https://localhost:7258";
+            }
+
+            return $"{baseUrl.TrimEnd('/')}/{path.TrimStart('/')}";
         }
     }
 }

--- a/BlazorShop.Presentation/BlazorShop.API/Program.cs
+++ b/BlazorShop.Presentation/BlazorShop.API/Program.cs
@@ -7,6 +7,7 @@ namespace BlazorShop.API
     using BlazorShop.Infrastructure.Data;
 
     using Microsoft.AspNetCore.Builder;
+    using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.FileProviders;
     using Microsoft.Extensions.Hosting;
 
@@ -74,7 +75,15 @@ namespace BlazorShop.API
                 using (var scope = app.Services.CreateScope())
                 {
                     var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-                    db.Database.EnsureCreated();
+
+                    if (db.Database.GetMigrations().Any())
+                    {
+                        db.Database.Migrate();
+                    }
+                    else
+                    {
+                        db.Database.EnsureCreated();
+                    }
                 }
 
                 app.UseCors();
@@ -112,6 +121,7 @@ namespace BlazorShop.API
                 app.UseAuthorization();
 
                 app.MapControllers();
+                app.MapDefaultEndpoints();
 
                 Log.Logger.Information("Application Started");
 

--- a/BlazorShop.Presentation/BlazorShop.API/appsettings.json
+++ b/BlazorShop.Presentation/BlazorShop.API/appsettings.json
@@ -16,6 +16,9 @@
     "Issuer": "https://localhost:7094",
     "Audience": "https://localhost:7094"
   },
+  "ClientApp": {
+    "BaseUrl": "https://localhost:7258"
+  },
   "Stripe": {
     "SecretKey": "super secret key"
   },

--- a/BlazorShop.Presentation/BlazorShop.Web.Shared/Constant.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web.Shared/Constant.cs
@@ -32,7 +32,7 @@
             public const string Type = "Bearer";
             public const string Register = "authentication/create";
             public const string Login = "authentication/login";
-            public const string ReviveToke = "authentication/refreshToken";
+            public const string ReviveToke = "authentication/refresh-token";
             public const string ChangePassword = "authentication/change-password";
             public const string ConfirmEmail = "authentication/confirm-email";
             public const string UpdateProfile = "authentication/update-profile";

--- a/BlazorShop.Presentation/BlazorShop.Web.Shared/Services/AuthenticationService.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web.Shared/Services/AuthenticationService.cs
@@ -91,13 +91,12 @@
             var currentApiCall = new ApiCall
             {
                 Route = Constant.Authentication.ReviveToke,
-                Type = Constant.ApiCallType.Get,
+                Type = Constant.ApiCallType.Post,
                 Client = client,
-                Model = null!,
-                Id = HttpUtility.UrlEncode(refreshToken),
+                Model = refreshToken,
             };
 
-            var result = await _apiCallHelper.ApiCallTypeCall<Unit>(currentApiCall);
+            var result = await _apiCallHelper.ApiCallTypeCall<string>(currentApiCall);
 
             return result is null || !result.IsSuccessStatusCode
                        ? new LoginResponse(Message: this._apiCallHelper.ConnectionError().Message)

--- a/BlazorShop.Presentation/BlazorShop.Web/BlazorShop.Web.csproj
+++ b/BlazorShop.Presentation/BlazorShop.Web/BlazorShop.Web.csproj
@@ -23,10 +23,18 @@
     <Folder Include="wwwroot\uploads\" />
   </ItemGroup>
 
+  <!-- Restore npm dependencies only when package inputs change -->
+  <Target Name="RestoreNodeModules"
+          BeforeTargets="Build"
+          Inputs="$(MSBuildProjectDirectory)\package.json;$(MSBuildProjectDirectory)\package-lock.json"
+          Outputs="$(MSBuildProjectDirectory)\node_modules\.package-lock.json">
+    <Message Text="Restoring npm packages..." Importance="high" />
+    <Exec Command="npm ci" WorkingDirectory="$(MSBuildProjectDirectory)" />
+  </Target>
+
   <!-- Tailwind build on publish/build -->
-  <Target Name="TailwindBuild" BeforeTargets="Build">
+  <Target Name="TailwindBuild" BeforeTargets="Build" DependsOnTargets="RestoreNodeModules">
     <Message Text="Running Tailwind build..." Importance="high" />
-    <Exec Command="npm install" WorkingDirectory="$(MSBuildProjectDirectory)" />
     <Exec Command="npm run tailwind:build" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 

--- a/BlazorShop.Tests/Application/Services/Authentication/AuthenticationServiceTests.cs
+++ b/BlazorShop.Tests/Application/Services/Authentication/AuthenticationServiceTests.cs
@@ -411,6 +411,7 @@ namespace BlazorShop.Tests.Application.Services.Authentication
             _userManagerMock.Setup(u => u.GetUserClaimsAsync(appUser.Email)).ReturnsAsync(claims);
             _tokenManagerMock.Setup(t => t.GenerateAccessToken(claims)).Returns(newAccessToken);
             _tokenManagerMock.Setup(t => t.GetReFreshToken()).Returns(newRefreshToken);
+            _tokenManagerMock.Setup(t => t.UpdateRefreshTokenAsync(userId, newRefreshToken)).ReturnsAsync(1);
 
             // Act
             var result = await _authenticationService.ReviveToken(refreshToken);

--- a/BlazorShop.Tests/Presentation/Services/Authentication/AuthenticationServiceTests.cs
+++ b/BlazorShop.Tests/Presentation/Services/Authentication/AuthenticationServiceTests.cs
@@ -286,7 +286,7 @@ namespace BlazorShop.Tests.Presentation.Services.Authentication
             };
 
             this._httpClientHelperMock.Setup(h => h.GetPublicClient()).Returns(httpClient);
-            this._apiCallHelperMock.Setup(a => a.ApiCallTypeCall<Unit>(It.IsAny<ApiCall>())).ReturnsAsync(apiCallResult);
+            this._apiCallHelperMock.Setup(a => a.ApiCallTypeCall<string>(It.IsAny<ApiCall>())).ReturnsAsync(apiCallResult);
             this._apiCallHelperMock.Setup(a => a.GetServiceResponse<LoginResponse>(apiCallResult)).ReturnsAsync(loginResponse);
 
             // Act
@@ -309,7 +309,7 @@ namespace BlazorShop.Tests.Presentation.Services.Authentication
             HttpResponseMessage apiCallResult = null!;
 
             this._httpClientHelperMock.Setup(h => h.GetPublicClient()).Returns(httpClient);
-            this._apiCallHelperMock.Setup(a => a.ApiCallTypeCall<Unit>(It.IsAny<ApiCall>())).ReturnsAsync(apiCallResult);
+            this._apiCallHelperMock.Setup(a => a.ApiCallTypeCall<string>(It.IsAny<ApiCall>())).ReturnsAsync(apiCallResult);
             this._apiCallHelperMock.Setup(a => a.ConnectionError()).Returns(new ServiceResponse { Success = false, Message = "Connection error" });
 
             // Act


### PR DESCRIPTION
Centralize client app URL config, update token refresh API

Introduce ClientAppOptions for base URL config, replacing hardcoded URLs in services and controllers. Change token refresh endpoint to POST with body. Improve refresh token handling in AppTokenManager. Update DB init to use migrations if present. Optimize npm/Tailwind build steps. Update tests and perform minor cleanups.