### PR TITLE
Add paged product catalog API and frontend integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
           BLAZORSHOP_DB_PASSWORD: ci-db-password
           BLAZORSHOP_JWT_KEY: ci-jwt-signing-key-which-is-long-enough
           BLAZORSHOP_STRIPE_SECRET_KEY: sk_test_placeholder
+          BLAZORSHOP_EMAIL_FROM: shop@example.com
+          BLAZORSHOP_EMAIL_SMTP_SERVER: smtp.example.com
           BLAZORSHOP_EMAIL_USERNAME: ci@example.com
           BLAZORSHOP_EMAIL_PASSWORD: ci-email-password
           BLAZORSHOP_PUBLIC_BASE_URL: https://shop.example.com

--- a/BlazorShop.Application/DTOs/Product/GetCatalogProduct.cs
+++ b/BlazorShop.Application/DTOs/Product/GetCatalogProduct.cs
@@ -1,0 +1,31 @@
+namespace BlazorShop.Application.DTOs.Product
+{
+    using System.ComponentModel.DataAnnotations;
+
+    public sealed class GetCatalogProduct
+    {
+        [Required]
+        public Guid Id { get; set; }
+
+        [Required]
+        public string? Name { get; set; }
+
+        [Required]
+        public string? Description { get; set; }
+
+        [Required]
+        [DataType(DataType.Currency)]
+        public decimal Price { get; set; }
+
+        [Required]
+        public string? Image { get; set; }
+
+        [Required]
+        public DateTime CreatedOn { get; set; }
+
+        [Required]
+        public Guid CategoryId { get; set; }
+
+        public bool HasVariants { get; set; }
+    }
+}

--- a/BlazorShop.Application/Mapping/MappingConfig.cs
+++ b/BlazorShop.Application/Mapping/MappingConfig.cs
@@ -7,6 +7,7 @@
     using BlazorShop.Application.DTOs.Product;
     using BlazorShop.Application.DTOs.Product.ProductVariant;
     using BlazorShop.Application.DTOs.UserIdentity;
+    using BlazorShop.Domain.Contracts;
     using BlazorShop.Domain.Entities;
     using BlazorShop.Domain.Entities.Identity;
     using BlazorShop.Domain.Entities.Payment;
@@ -24,6 +25,7 @@
             this.CreateMap<UpdateProduct, Product>();
             this.CreateMap<Product, GetProduct>()
                 .ForMember(dest => dest.Variants, opt => opt.MapFrom(src => src.Variants));
+            this.CreateMap<CatalogProductReadModel, GetCatalogProduct>();
 
             this.CreateMap<Product, GetProductRecommendation>()
                 .ForMember(dest => dest.CategoryName, opt => opt.MapFrom(src => src.Category != null ? src.Category.Name : null));

--- a/BlazorShop.Application/Services/Contracts/IProductService.cs
+++ b/BlazorShop.Application/Services/Contracts/IProductService.cs
@@ -2,10 +2,13 @@
 {
     using BlazorShop.Application.DTOs;
     using BlazorShop.Application.DTOs.Product;
+    using BlazorShop.Domain.Contracts;
 
     public interface IProductService
     {
         Task<IEnumerable<GetProduct>> GetAllAsync();
+
+        Task<PagedResult<GetCatalogProduct>> GetCatalogPageAsync(ProductCatalogQuery query);
 
         Task<GetProduct?> GetByIdAsync(Guid id);
 

--- a/BlazorShop.Application/Services/ProductService.cs
+++ b/BlazorShop.Application/Services/ProductService.cs
@@ -30,6 +30,20 @@
             return result.Any() ? mappedData : [];
         }
 
+        public async Task<PagedResult<GetCatalogProduct>> GetCatalogPageAsync(ProductCatalogQuery query)
+        {
+            var result = await _productReadRepository.GetCatalogPageAsync(query);
+            var mappedItems = _mapper.Map<IReadOnlyList<GetCatalogProduct>>(result.Items);
+
+            return new PagedResult<GetCatalogProduct>
+            {
+                Items = mappedItems,
+                PageNumber = result.PageNumber,
+                PageSize = result.PageSize,
+                TotalCount = result.TotalCount,
+            };
+        }
+
         public async Task<GetProduct?> GetByIdAsync(Guid id)
         {
             var result = await _productReadRepository.GetProductDetailsByIdAsync(id);

--- a/BlazorShop.Domain/Contracts/CatalogProductReadModel.cs
+++ b/BlazorShop.Domain/Contracts/CatalogProductReadModel.cs
@@ -1,0 +1,21 @@
+namespace BlazorShop.Domain.Contracts
+{
+    public sealed class CatalogProductReadModel
+    {
+        public Guid Id { get; init; }
+
+        public string? Name { get; init; }
+
+        public string? Description { get; init; }
+
+        public decimal Price { get; init; }
+
+        public string? Image { get; init; }
+
+        public DateTime CreatedOn { get; init; }
+
+        public Guid CategoryId { get; init; }
+
+        public bool HasVariants { get; init; }
+    }
+}

--- a/BlazorShop.Domain/Contracts/IProductReadRepository.cs
+++ b/BlazorShop.Domain/Contracts/IProductReadRepository.cs
@@ -6,6 +6,8 @@ namespace BlazorShop.Domain.Contracts
     {
         Task<IEnumerable<Product>> GetCatalogProductsAsync();
 
+        Task<PagedResult<CatalogProductReadModel>> GetCatalogPageAsync(ProductCatalogQuery query);
+
         Task<Product?> GetProductDetailsByIdAsync(Guid id);
 
         Task<IReadOnlyDictionary<Guid, Product>> GetProductsByIdsAsync(IEnumerable<Guid> productIds);

--- a/BlazorShop.Domain/Contracts/PagedResult.cs
+++ b/BlazorShop.Domain/Contracts/PagedResult.cs
@@ -1,0 +1,17 @@
+namespace BlazorShop.Domain.Contracts
+{
+    public sealed class PagedResult<T>
+    {
+        public IReadOnlyList<T> Items { get; init; } = Array.Empty<T>();
+
+        public int PageNumber { get; init; }
+
+        public int PageSize { get; init; }
+
+        public int TotalCount { get; init; }
+
+        public int TotalPages => this.PageSize <= 0
+            ? 0
+            : (int)Math.Ceiling((double)this.TotalCount / this.PageSize);
+    }
+}

--- a/BlazorShop.Domain/Contracts/ProductCatalogQuery.cs
+++ b/BlazorShop.Domain/Contracts/ProductCatalogQuery.cs
@@ -1,0 +1,29 @@
+namespace BlazorShop.Domain.Contracts
+{
+    public sealed class ProductCatalogQuery
+    {
+        private const int DefaultPageNumber = 1;
+        private const int DefaultPageSize = 24;
+        private const int MaxPageSize = 100;
+
+        public int PageNumber { get; init; } = DefaultPageNumber;
+
+        public int PageSize { get; init; } = DefaultPageSize;
+
+        public Guid? CategoryId { get; init; }
+
+        public string? SearchTerm { get; init; }
+
+        public ProductCatalogSortBy SortBy { get; init; } = ProductCatalogSortBy.Newest;
+
+        public DateTime? CreatedAfterUtc { get; init; }
+
+        public int GetNormalizedPageNumber() => this.PageNumber < 1 ? DefaultPageNumber : this.PageNumber;
+
+        public int GetNormalizedPageSize() => Math.Clamp(this.PageSize, 1, MaxPageSize);
+
+        public string? GetNormalizedSearchTerm() => string.IsNullOrWhiteSpace(this.SearchTerm)
+            ? null
+            : this.SearchTerm.Trim();
+    }
+}

--- a/BlazorShop.Domain/Contracts/ProductCatalogSortBy.cs
+++ b/BlazorShop.Domain/Contracts/ProductCatalogSortBy.cs
@@ -1,0 +1,12 @@
+namespace BlazorShop.Domain.Contracts
+{
+    public enum ProductCatalogSortBy
+    {
+        Newest = 0,
+        Oldest = 1,
+        PriceLowToHigh = 2,
+        PriceHighToLow = 3,
+        NameAscending = 4,
+        NameDescending = 5,
+    }
+}

--- a/BlazorShop.Infrastructure/Configuration/EmailSettingsOptionsValidator.cs
+++ b/BlazorShop.Infrastructure/Configuration/EmailSettingsOptionsValidator.cs
@@ -1,0 +1,77 @@
+namespace BlazorShop.Infrastructure.Configuration
+{
+    using System.Net.Mail;
+
+    using BlazorShop.Application.DTOs;
+
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Options;
+
+    public sealed class EmailSettingsOptionsValidator : IValidateOptions<EmailSettings>
+    {
+        private readonly IHostEnvironment _hostEnvironment;
+
+        public EmailSettingsOptionsValidator(IHostEnvironment hostEnvironment)
+        {
+            _hostEnvironment = hostEnvironment;
+        }
+
+        public ValidateOptionsResult Validate(string? name, EmailSettings options)
+        {
+            if (_hostEnvironment.IsDevelopment())
+            {
+                return ValidateOptionsResult.Success;
+            }
+
+            List<string> failures = [];
+
+            if (IsMissingOrPlaceholder(options.From) || !IsValidEmailAddress(options.From))
+            {
+                failures.Add("EmailSettings:From is required and must be a valid email address outside Development.");
+            }
+
+            if (IsMissingOrPlaceholder(options.SmtpServer))
+            {
+                failures.Add("EmailSettings:SmtpServer is required outside Development.");
+            }
+
+            if (options.Port <= 0 || options.Port > 65535)
+            {
+                failures.Add("EmailSettings:Port must be between 1 and 65535.");
+            }
+
+            if (IsMissingOrPlaceholder(options.Username))
+            {
+                failures.Add("EmailSettings:Username is required outside Development.");
+            }
+
+            if (IsMissingOrPlaceholder(options.Password))
+            {
+                failures.Add("EmailSettings:Password is required outside Development.");
+            }
+
+            return failures.Count == 0
+                ? ValidateOptionsResult.Success
+                : ValidateOptionsResult.Fail(failures);
+        }
+
+        private static bool IsMissingOrPlaceholder(string? value)
+        {
+            return string.IsNullOrWhiteSpace(value)
+                || (value.StartsWith('<') && value.EndsWith('>'));
+        }
+
+        private static bool IsValidEmailAddress(string value)
+        {
+            try
+            {
+                _ = new MailAddress(value);
+                return true;
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/BlazorShop.Infrastructure/DependencyInjection.cs
+++ b/BlazorShop.Infrastructure/DependencyInjection.cs
@@ -11,6 +11,7 @@
     using BlazorShop.Domain.Contracts.Newsletters;
     using BlazorShop.Domain.Contracts.Payment;
     using BlazorShop.Domain.Entities.Identity;
+    using BlazorShop.Infrastructure.Configuration;
     using BlazorShop.Infrastructure.Data;
     using BlazorShop.Infrastructure.ExceptionsMiddleware;
     using BlazorShop.Infrastructure.Repositories;
@@ -26,6 +27,7 @@
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Options;
     using Microsoft.IdentityModel.Tokens;
 
     public static class DependencyInjection
@@ -112,7 +114,10 @@
 
             Stripe.StripeConfiguration.ApiKey = config["Stripe:SecretKey"];
 
-            services.Configure<EmailSettings>(config.GetSection("EmailSettings"));
+            services.AddSingleton<IValidateOptions<EmailSettings>, EmailSettingsOptionsValidator>();
+            services.AddOptions<EmailSettings>()
+                .Bind(config.GetSection("EmailSettings"))
+                .ValidateOnStart();
             services.Configure<BankTransferSettings>(config.GetSection("BankTransfer"));
             services.AddTransient<IEmailService, EmailService>();
 

--- a/BlazorShop.Infrastructure/Repositories/ProductReadRepository.cs
+++ b/BlazorShop.Infrastructure/Repositories/ProductReadRepository.cs
@@ -19,9 +19,81 @@ namespace BlazorShop.Infrastructure.Repositories
         {
             return await _context.Products
                 .AsNoTracking()
-                .Include(product => product.Category)
-                .Include(product => product.Variants)
+                .OrderByDescending(product => product.CreatedOn)
+                .Select(product => new Product
+                {
+                    Id = product.Id,
+                    Name = product.Name,
+                    Description = product.Description,
+                    Price = product.Price,
+                    Image = product.Image,
+                    Quantity = product.Quantity,
+                    CreatedOn = product.CreatedOn,
+                    CategoryId = product.CategoryId,
+                })
                 .ToListAsync();
+        }
+
+        public async Task<PagedResult<CatalogProductReadModel>> GetCatalogPageAsync(ProductCatalogQuery query)
+        {
+            var pageNumber = query.GetNormalizedPageNumber();
+            var pageSize = query.GetNormalizedPageSize();
+            var searchTerm = query.GetNormalizedSearchTerm();
+
+            IQueryable<Product> products = _context.Products.AsNoTracking();
+
+            if (query.CategoryId.HasValue && query.CategoryId.Value != Guid.Empty)
+            {
+                products = products.Where(product => product.CategoryId == query.CategoryId.Value);
+            }
+
+            if (query.CreatedAfterUtc.HasValue)
+            {
+                products = products.Where(product => product.CreatedOn >= query.CreatedAfterUtc.Value);
+            }
+
+            if (!string.IsNullOrWhiteSpace(searchTerm))
+            {
+                var normalizedSearchTerm = searchTerm.ToLower();
+                products = products.Where(product =>
+                    (product.Name != null && product.Name.ToLower().Contains(normalizedSearchTerm)) ||
+                    (product.Description != null && product.Description.ToLower().Contains(normalizedSearchTerm)));
+            }
+
+            products = query.SortBy switch
+            {
+                ProductCatalogSortBy.Oldest => products.OrderBy(product => product.CreatedOn).ThenBy(product => product.Id),
+                ProductCatalogSortBy.PriceLowToHigh => products.OrderBy(product => product.Price).ThenBy(product => product.Id),
+                ProductCatalogSortBy.PriceHighToLow => products.OrderByDescending(product => product.Price).ThenBy(product => product.Id),
+                ProductCatalogSortBy.NameAscending => products.OrderBy(product => product.Name).ThenBy(product => product.Id),
+                ProductCatalogSortBy.NameDescending => products.OrderByDescending(product => product.Name).ThenBy(product => product.Id),
+                _ => products.OrderByDescending(product => product.CreatedOn).ThenBy(product => product.Id),
+            };
+
+            var totalCount = await products.CountAsync();
+            var items = await products
+                .Skip((pageNumber - 1) * pageSize)
+                .Take(pageSize)
+                .Select(product => new CatalogProductReadModel
+                {
+                    Id = product.Id,
+                    Name = product.Name,
+                    Description = product.Description,
+                    Price = product.Price,
+                    Image = product.Image,
+                    CreatedOn = product.CreatedOn,
+                    CategoryId = product.CategoryId,
+                    HasVariants = product.Variants.Any(),
+                })
+                .ToListAsync();
+
+            return new PagedResult<CatalogProductReadModel>
+            {
+                Items = items,
+                PageNumber = pageNumber,
+                PageSize = pageSize,
+                TotalCount = totalCount,
+            };
         }
 
         public async Task<Product?> GetProductDetailsByIdAsync(Guid id)

--- a/BlazorShop.Presentation/BlazorShop.API/Controllers/ProductController.cs
+++ b/BlazorShop.Presentation/BlazorShop.API/Controllers/ProductController.cs
@@ -2,6 +2,7 @@
 {
     using BlazorShop.Application.DTOs.Product;
     using BlazorShop.Application.Services.Contracts;
+    using BlazorShop.Domain.Contracts;
 
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
@@ -25,6 +26,18 @@
         public async Task<ActionResult<IEnumerable<GetProduct>>> GetAll()
         {
             var data = await _productService.GetAllAsync();
+            return Ok(data);
+        }
+
+        /// <summary>
+        /// Get a paged product catalog for list pages.
+        /// </summary>
+        /// <param name="query">Catalog paging, filtering and sorting options.</param>
+        /// <returns>Paged catalog items.</returns>
+        [HttpGet("catalog")]
+        public async Task<ActionResult<PagedResult<GetCatalogProduct>>> GetCatalog([FromQuery] ProductCatalogQuery query)
+        {
+            var data = await _productService.GetCatalogPageAsync(query);
             return Ok(data);
         }
 

--- a/BlazorShop.Presentation/BlazorShop.API/Dockerfile
+++ b/BlazorShop.Presentation/BlazorShop.API/Dockerfile
@@ -1,4 +1,7 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG DOTNET_SDK_IMAGE=mcr.microsoft.com/dotnet/sdk:10.0.202-noble
+ARG DOTNET_ASPNET_IMAGE=mcr.microsoft.com/dotnet/aspnet:10.0.6-noble
+
+FROM ${DOTNET_SDK_IMAGE} AS build
 WORKDIR /src
 
 COPY BlazorShop.Presentation/BlazorShop.API/BlazorShop.API.csproj BlazorShop.Presentation/BlazorShop.API/
@@ -20,7 +23,7 @@ RUN dotnet publish BlazorShop.Presentation/BlazorShop.API/BlazorShop.API.csproj 
     --output /app/publish \
     /p:UseAppHost=false
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
+FROM ${DOTNET_ASPNET_IMAGE} AS final
 WORKDIR /app
 
 COPY --from=build /app/publish .

--- a/BlazorShop.Presentation/BlazorShop.API/appsettings.json
+++ b/BlazorShop.Presentation/BlazorShop.API/appsettings.json
@@ -29,13 +29,13 @@
     "AdditionalInfo": "Include the reference in the transfer reason."
   },
   "EmailSettings": {
-    "From": "shop@blazorshop.com",
+    "From": "<required-sender-address>",
     "DisplayName": "BlazorShop",
-    "SmtpServer": "smtp.email.com",
+    "SmtpServer": "<required-smtp-host>",
     "Port": 587,
     "UseSsl": false,
-    "Username": "<set-in-user-secrets>",
-    "Password": "<set-in-user-secrets>"
+    "Username": "<required-smtp-username>",
+    "Password": "<required-smtp-password>"
   },
   "Recommendations": {
     "MaxRecommendations": 6,

--- a/BlazorShop.Presentation/BlazorShop.Web.Shared/Constant.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web.Shared/Constant.cs
@@ -5,6 +5,7 @@
         public static class Product
         {
             public const string GetAll = "product/all";
+            public const string GetCatalog = "product/catalog";
             public const string Get = "product/single";
             public const string Add = "product/add";
             public const string Update = "product/update";

--- a/BlazorShop.Presentation/BlazorShop.Web.Shared/Models/PagedResult.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web.Shared/Models/PagedResult.cs
@@ -1,0 +1,17 @@
+namespace BlazorShop.Web.Shared.Models
+{
+    public sealed class PagedResult<T>
+    {
+        public IReadOnlyList<T> Items { get; set; } = Array.Empty<T>();
+
+        public int PageNumber { get; set; }
+
+        public int PageSize { get; set; }
+
+        public int TotalCount { get; set; }
+
+        public int TotalPages => this.PageSize <= 0
+            ? 0
+            : (int)Math.Ceiling((double)this.TotalCount / this.PageSize);
+    }
+}

--- a/BlazorShop.Presentation/BlazorShop.Web.Shared/Models/Product/GetCatalogProduct.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web.Shared/Models/Product/GetCatalogProduct.cs
@@ -1,0 +1,33 @@
+namespace BlazorShop.Web.Shared.Models.Product
+{
+    using System.ComponentModel.DataAnnotations;
+
+    public sealed class GetCatalogProduct
+    {
+        [Required]
+        public Guid Id { get; set; }
+
+        [Required(ErrorMessage = "The Name field is required.")]
+        public string? Name { get; set; }
+
+        [Required(ErrorMessage = "The Description field is required.")]
+        public string? Description { get; set; }
+
+        [Required(ErrorMessage = "The Price field is required.")]
+        [DataType(DataType.Currency)]
+        public decimal Price { get; set; }
+
+        [Required(ErrorMessage = "The Image field is required.")]
+        public string? Image { get; set; }
+
+        [Required]
+        public DateTime CreatedOn { get; set; }
+
+        [Required(ErrorMessage = "The Category field is required.")]
+        public Guid CategoryId { get; set; }
+
+        public bool HasVariants { get; set; }
+
+        public bool IsNew => DateTime.UtcNow.Subtract(this.CreatedOn).TotalDays <= 7;
+    }
+}

--- a/BlazorShop.Presentation/BlazorShop.Web.Shared/Models/Product/ProductCatalogQuery.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web.Shared/Models/Product/ProductCatalogQuery.cs
@@ -1,0 +1,17 @@
+namespace BlazorShop.Web.Shared.Models.Product
+{
+    public sealed class ProductCatalogQuery
+    {
+        public int PageNumber { get; set; } = 1;
+
+        public int PageSize { get; set; } = 24;
+
+        public Guid? CategoryId { get; set; }
+
+        public string? SearchTerm { get; set; }
+
+        public ProductCatalogSortBy SortBy { get; set; } = ProductCatalogSortBy.Newest;
+
+        public DateTime? CreatedAfterUtc { get; set; }
+    }
+}

--- a/BlazorShop.Presentation/BlazorShop.Web.Shared/Models/Product/ProductCatalogSortBy.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web.Shared/Models/Product/ProductCatalogSortBy.cs
@@ -1,0 +1,12 @@
+namespace BlazorShop.Web.Shared.Models.Product
+{
+    public enum ProductCatalogSortBy
+    {
+        Newest = 0,
+        Oldest = 1,
+        PriceLowToHigh = 2,
+        PriceHighToLow = 3,
+        NameAscending = 4,
+        NameDescending = 5,
+    }
+}

--- a/BlazorShop.Presentation/BlazorShop.Web.Shared/Services/Contracts/IProductService.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web.Shared/Services/Contracts/IProductService.cs
@@ -7,6 +7,8 @@
     {
         Task<QueryResult<IEnumerable<GetProduct>>> GetAllAsync();
 
+        Task<QueryResult<PagedResult<GetCatalogProduct>>> GetCatalogPageAsync(ProductCatalogQuery query);
+
         Task<QueryResult<GetProduct>> GetByIdAsync(Guid id);
 
         Task<ServiceResponse> AddAsync(CreateProduct product);

--- a/BlazorShop.Presentation/BlazorShop.Web.Shared/Services/ProductService.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web.Shared/Services/ProductService.cs
@@ -1,5 +1,7 @@
 ﻿namespace BlazorShop.Web.Shared.Services
 {
+    using System.Globalization;
+
     using BlazorShop.Web.Shared.Helper.Contracts;
     using BlazorShop.Web.Shared.Models;
     using BlazorShop.Web.Shared.Models.Product;
@@ -32,6 +34,22 @@
             return await _apiCallHelper.GetQueryResult<IEnumerable<GetProduct>>(
                 result,
                 "We couldn't load products right now. Please try again.");
+        }
+
+        public async Task<QueryResult<PagedResult<GetCatalogProduct>>> GetCatalogPageAsync(ProductCatalogQuery query)
+        {
+            var client = _httpClientHelper.GetPublicClient();
+            var currentApiCall = new ApiCall
+            {
+                Route = BuildCatalogRoute(query),
+                Type = Constant.ApiCallType.Get,
+                Client = client,
+            };
+
+            var result = await _apiCallHelper.ApiCallTypeCall<Unit>(currentApiCall);
+            return await _apiCallHelper.GetQueryResult<PagedResult<GetCatalogProduct>>(
+                result,
+                "We couldn't load the product catalog right now. Please try again.");
         }
 
         public async Task<QueryResult<GetProduct>> GetByIdAsync(Guid id)
@@ -106,6 +124,33 @@
             return result is null || !result.IsSuccessStatusCode
                        ? _apiCallHelper.ConnectionError()
                        : await _apiCallHelper.GetServiceResponse<ServiceResponse>(result);
+        }
+
+        private static string BuildCatalogRoute(ProductCatalogQuery query)
+        {
+            var parameters = new List<string>
+            {
+                $"pageNumber={Math.Max(1, query.PageNumber)}",
+                $"pageSize={Math.Max(1, query.PageSize)}",
+                $"sortBy={Uri.EscapeDataString(query.SortBy.ToString())}",
+            };
+
+            if (query.CategoryId.HasValue && query.CategoryId.Value != Guid.Empty)
+            {
+                parameters.Add($"categoryId={query.CategoryId.Value}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(query.SearchTerm))
+            {
+                parameters.Add($"searchTerm={Uri.EscapeDataString(query.SearchTerm.Trim())}");
+            }
+
+            if (query.CreatedAfterUtc.HasValue)
+            {
+                parameters.Add($"createdAfterUtc={Uri.EscapeDataString(query.CreatedAfterUtc.Value.ToString("O", CultureInfo.InvariantCulture))}");
+            }
+
+            return $"{Constant.Product.GetCatalog}?{string.Join("&", parameters)}";
         }
     }
 }

--- a/BlazorShop.Presentation/BlazorShop.Web/Authentication/Components/Logout.razor
+++ b/BlazorShop.Presentation/BlazorShop.Web/Authentication/Components/Logout.razor
@@ -1,4 +1,5 @@
 ﻿@page "/authentication/logout"
+@inject BlazorShop.Web.Authentication.Providers.IAuthenticationStateNotifier AuthenticationStateNotifier
 
 @code {
 
@@ -6,6 +7,7 @@
     {
         await AuthenticationService.Logout();
         await TokenService.RemoveJwtTokenAsync(Constant.TokenStorage.Key);
+        AuthenticationStateNotifier.NotifyAuthenticationState();
         NavigationManager.NavigateTo("/", true);
     }
 }

--- a/BlazorShop.Presentation/BlazorShop.Web/Authentication/Providers/AuthenticationStateNotifier.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web/Authentication/Providers/AuthenticationStateNotifier.cs
@@ -1,0 +1,23 @@
+namespace BlazorShop.Web.Authentication.Providers
+{
+    using Microsoft.AspNetCore.Components.Authorization;
+    using Microsoft.Extensions.DependencyInjection;
+
+    public sealed class AuthenticationStateNotifier : IAuthenticationStateNotifier
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public AuthenticationStateNotifier(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public void NotifyAuthenticationState()
+        {
+            if (_serviceProvider.GetService<AuthenticationStateProvider>() is CustomAuthStateProvider authStateProvider)
+            {
+                authStateProvider.NotifyAuthenticationState();
+            }
+        }
+    }
+}

--- a/BlazorShop.Presentation/BlazorShop.Web/Authentication/Providers/IAuthenticationStateNotifier.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web/Authentication/Providers/IAuthenticationStateNotifier.cs
@@ -1,0 +1,7 @@
+namespace BlazorShop.Web.Authentication.Providers
+{
+    public interface IAuthenticationStateNotifier
+    {
+        void NotifyAuthenticationState();
+    }
+}

--- a/BlazorShop.Presentation/BlazorShop.Web/Authentication/Providers/RefreshTokenHandler.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web/Authentication/Providers/RefreshTokenHandler.cs
@@ -14,13 +14,16 @@
 
         private readonly ITokenService _tokenService;
         private readonly IAuthenticationService _authenticationService;
+        private readonly IAuthenticationStateNotifier _authenticationStateNotifier;
 
         public RefreshTokenHandler(
             ITokenService tokenService,
-            IAuthenticationService authenticationService)
+            IAuthenticationService authenticationService,
+            IAuthenticationStateNotifier authenticationStateNotifier)
         {
             this._tokenService = tokenService;
             this._authenticationService = authenticationService;
+            this._authenticationStateNotifier = authenticationStateNotifier;
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -57,11 +60,13 @@
             if (result.Success && !string.IsNullOrWhiteSpace(result.Token))
             {
                 await _tokenService.StoreJwtTokenAsync(Constant.TokenStorage.Key, result.Token);
+                _authenticationStateNotifier.NotifyAuthenticationState();
 
                 return result;
             }
 
             await _tokenService.RemoveJwtTokenAsync(Constant.TokenStorage.Key);
+            _authenticationStateNotifier.NotifyAuthenticationState();
             return null;
         }
     }

--- a/BlazorShop.Presentation/BlazorShop.Web/Components/Header/SearchBarComponent.razor.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web/Components/Header/SearchBarComponent.razor.cs
@@ -1,44 +1,73 @@
 ﻿namespace BlazorShop.Web.Components.Header
 {
-    using System.Linq;
     using BlazorShop.Web.Shared.Models.Product;
+
     using Microsoft.AspNetCore.Components;
     using Microsoft.AspNetCore.Components.Web;
 
     public partial class SearchBarComponent
     {
-        [Parameter]
-        public IEnumerable<GetProduct> Products { get; set; } = Enumerable.Empty<GetProduct>();
-
         private string _query = string.Empty;
-        private List<GetProduct> _matches = new();
+        private List<GetCatalogProduct> _matches = new();
         private bool _isOpen;
         private int _activeIndex = -1;
+        private CancellationTokenSource? _searchCts;
 
-        private void OnInput(ChangeEventArgs e)
+        private async Task OnInput(ChangeEventArgs e)
         {
             _query = e.Value?.ToString() ?? string.Empty;
-            Filter();
-            _isOpen = _matches.Count > 0;
+            await FilterAsync();
         }
 
-        private void Filter()
+        private async Task FilterAsync()
         {
-            if (string.IsNullOrWhiteSpace(_query))
+            _searchCts?.Cancel();
+            _searchCts?.Dispose();
+            _searchCts = new CancellationTokenSource();
+
+            if (string.IsNullOrWhiteSpace(_query) || _query.Trim().Length < 2)
             {
                 _matches.Clear();
                 _activeIndex = -1;
+                _isOpen = false;
                 return;
             }
 
+            var token = _searchCts.Token;
             var q = _query.Trim();
-            _matches = Products
-                .Where(x => (x.Name?.Contains(q, StringComparison.CurrentCultureIgnoreCase) ?? false)
-                         || (x.Description?.Contains(q, StringComparison.CurrentCultureIgnoreCase) ?? false))
-                .Take(8)
-                .ToList();
 
-            _activeIndex = _matches.Count > 0 ? 0 : -1;
+            try
+            {
+                await Task.Delay(150, token);
+
+                var result = await this.ProductService.GetCatalogPageAsync(new ProductCatalogQuery
+                {
+                    PageNumber = 1,
+                    PageSize = 8,
+                    SearchTerm = q,
+                    SortBy = ProductCatalogSortBy.NameAscending,
+                });
+
+                if (token.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                _matches = result.Success
+                    ? (result.Data?.Items ?? []).ToList()
+                    : [];
+                _activeIndex = _matches.Count > 0 ? 0 : -1;
+                _isOpen = _matches.Count > 0;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch
+            {
+                _matches.Clear();
+                _activeIndex = -1;
+                _isOpen = false;
+            }
         }
 
         private async Task OnBlur()

--- a/BlazorShop.Presentation/BlazorShop.Web/Components/Search/SearchResult.razor
+++ b/BlazorShop.Presentation/BlazorShop.Web/Components/Search/SearchResult.razor
@@ -32,11 +32,11 @@
 
                         <div class="mt-4 flex items-center justify-between">
                             <button class="inline-flex items-center gap-2 rounded-md bg-neutral-900 text-white px-3 py-1.5 text-sm font-medium hover:bg-neutral-800"
-                                    @onclick="() => AddItemToCart(product.Id)">
+                                    @onclick="() => HandleAddToCart(product)">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M6 6h15l-1.5 9h-12z" /><path d="M6 6 5 3H3" /></svg>
                                 Add To Cart
                             </button>
-                            <button class="inline-flex items-center rounded-md px-3 py-1.5 text-sm text-neutral-700 hover:text-neutral-900 hover:bg-neutral-100" @onclick="() => ShowDetails(product)">See More</button>
+                            <button class="inline-flex items-center rounded-md px-3 py-1.5 text-sm text-neutral-700 hover:text-neutral-900 hover:bg-neutral-100" @onclick="() => ShowDetailsAsync(product.Id)">See More</button>
                         </div>
                     </div>
                 </article>

--- a/BlazorShop.Presentation/BlazorShop.Web/Components/Search/SearchResult.razor.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web/Components/Search/SearchResult.razor.cs
@@ -11,7 +11,7 @@
 
     public partial class SearchResult : IAsyncDisposable
     {
-        private IEnumerable<GetProduct> _searchedProducts = [];
+        private IEnumerable<GetCatalogProduct> _searchedProducts = [];
         private List<ProcessCart> _myCarts = new();
         private bool _isAddingToCart = false;
 
@@ -30,29 +30,42 @@
                 return;
             }
 
-            var productsResult = await this.ProductService.GetAllAsync();
+            var productsResult = await this.ProductService.GetCatalogPageAsync(new ProductCatalogQuery
+            {
+                PageNumber = 1,
+                PageSize = 60,
+                SearchTerm = this.Filter,
+                SortBy = ProductCatalogSortBy.NameAscending,
+            });
             if (this.QueryFailureNotifier.TryNotifyFailure(productsResult, "Search"))
             {
                 this._searchedProducts = [];
                 return;
             }
 
-            var products = productsResult.Data ?? [];
-
-            if (products.Any())
-            {
-                var searchWords = this.Filter.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-
-                this._searchedProducts = products.Where(
-                        x => searchWords.Any(word => x.Name!.Contains(word, StringComparison.OrdinalIgnoreCase))
-                             || searchWords.Any(word => x.Description!.Contains(word, StringComparison.OrdinalIgnoreCase)))
-                    .ToList();
-            }
+            this._searchedProducts = productsResult.Data?.Items ?? [];
         }
 
-        private void ShowDetails(GetProduct product)
+        private async Task HandleAddToCart(GetCatalogProduct product)
         {
-            SelectedProduct = product;
+            if (product.HasVariants)
+            {
+                await ShowDetailsAsync(product.Id);
+                return;
+            }
+
+            await AddItemToCart(product.Id);
+        }
+
+        private async Task ShowDetailsAsync(Guid productId)
+        {
+            var productResult = await this.ProductService.GetByIdAsync(productId);
+            if (this.QueryFailureNotifier.TryNotifyFailure(productResult, "Product details") || productResult.Data is null)
+            {
+                return;
+            }
+
+            SelectedProduct = productResult.Data;
             _showModal = true;
         }
 

--- a/BlazorShop.Presentation/BlazorShop.Web/Dockerfile
+++ b/BlazorShop.Presentation/BlazorShop.Web/Dockerfile
@@ -1,4 +1,7 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG DOTNET_SDK_IMAGE=mcr.microsoft.com/dotnet/sdk:10.0.202-noble
+ARG NGINX_IMAGE=nginx:1.27.5-alpine3.21
+
+FROM ${DOTNET_SDK_IMAGE} AS build
 WORKDIR /src
 
 RUN apt-get update \
@@ -23,7 +26,7 @@ RUN dotnet publish BlazorShop.Presentation/BlazorShop.Web/BlazorShop.Web.csproj 
     --output /app/publish \
     /p:UseAppHost=false
 
-FROM nginx:1.27-alpine AS final
+FROM ${NGINX_IMAGE} AS final
 
 COPY BlazorShop.Presentation/BlazorShop.Web/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/publish/wwwroot /usr/share/nginx/html

--- a/BlazorShop.Presentation/BlazorShop.Web/Layout/Header.razor
+++ b/BlazorShop.Presentation/BlazorShop.Web/Layout/Header.razor
@@ -11,7 +11,7 @@
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
                 Categories
             </button>
-            <SearchBarComponent Products="@Products" />
+            <SearchBarComponent />
         </div>
         <div class="flex justify-end">
             <HeaderBoxComponent />

--- a/BlazorShop.Presentation/BlazorShop.Web/Layout/Header.razor.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web/Layout/Header.razor.cs
@@ -1,23 +1,8 @@
 ﻿namespace BlazorShop.Web.Layout
 {
-    using BlazorShop.Web.Shared.Models.Product;
-
     public partial class Header
     {
-        protected IEnumerable<GetProduct> Products = new List<GetProduct>();
         private bool _showCategories;
-
-        protected override async Task OnInitializedAsync()
-        {
-            var productsResult = await this.ProductService.GetAllAsync();
-            if (this.QueryFailureNotifier.TryNotifyFailure(productsResult, "Products"))
-            {
-                this.Products = [];
-                return;
-            }
-
-            this.Products = productsResult.Data ?? [];
-        }
 
         private void ToggleCategories() => _showCategories = !_showCategories;
     }

--- a/BlazorShop.Presentation/BlazorShop.Web/Layout/MainLayout.razor
+++ b/BlazorShop.Presentation/BlazorShop.Web/Layout/MainLayout.razor
@@ -40,7 +40,7 @@
             Categories
         </button>
         <div class="flex-1 flex justify-center">
-            <SearchBarComponent Products="@_headerProducts" />
+            <SearchBarComponent />
         </div>
         <div class="flex items-center gap-5 text-sm">
             <div class="relative inline-flex items-center gap-2">
@@ -122,8 +122,6 @@
 @code {
     private bool IsMobileMenuOpen;
     private bool _showCategories;
-    private IEnumerable<GetProduct> _headerProducts = Enumerable.Empty<GetProduct>();
-
     private int _cartCount;
     [Inject] private IJSRuntime Js { get; set; } = default!;
     private IJSObjectReference? _cartModule;
@@ -132,16 +130,6 @@
 
     protected override async Task OnInitializedAsync()
     {
-        var headerProductsResult = await ProductService.GetAllAsync();
-        if (QueryFailureNotifier.TryNotifyFailure(headerProductsResult, "Products"))
-        {
-            _headerProducts = Enumerable.Empty<GetProduct>();
-        }
-        else
-        {
-            _headerProducts = headerProductsResult.Data ?? Enumerable.Empty<GetProduct>();
-        }
-
         await LoadCartCountAsync();
     }
 

--- a/BlazorShop.Presentation/BlazorShop.Web/Pages/Payments/Cart.razor.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web/Pages/Payments/Cart.razor.cs
@@ -38,15 +38,7 @@
                 _myCarts = JsonSerializer.Deserialize<List<ProcessCart>>(cartJson) ?? [];
             }
 
-            var productsResult = await this.ProductService.GetAllAsync();
-            if (this.QueryFailureNotifier.TryNotifyFailure(productsResult, "Cart"))
-            {
-                _products = [];
-            }
-            else
-            {
-                _products = productsResult.Data ?? [];
-            }
+            await this.LoadCartProductsAsync();
 
             this.GetCart();
 
@@ -75,6 +67,35 @@
             }
 
             _selectedProducts = _selectedProducts.OrderBy(x => x.Name).ToList();
+        }
+
+        private async Task LoadCartProductsAsync()
+        {
+            var uniqueProductIds = _myCarts
+                .Select(cart => cart.ProductId)
+                .Where(id => id != Guid.Empty)
+                .Distinct()
+                .ToArray();
+
+            if (uniqueProductIds.Length == 0)
+            {
+                _products = [];
+                return;
+            }
+
+            var productTasks = uniqueProductIds.Select(id => this.ProductService.GetByIdAsync(id));
+            var productResults = await Task.WhenAll(productTasks);
+            var successfulProducts = new List<GetProduct>();
+
+            foreach (var productResult in productResults)
+            {
+                if (productResult.Success && productResult.Data is not null)
+                {
+                    successfulProducts.Add(productResult.Data);
+                }
+            }
+
+            _products = successfulProducts;
         }
 
         private int GetProductQuantity(Guid productId)

--- a/BlazorShop.Presentation/BlazorShop.Web/Pages/Products/LatestProducts.razor
+++ b/BlazorShop.Presentation/BlazorShop.Web/Pages/Products/LatestProducts.razor
@@ -26,7 +26,7 @@
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M6 6h15l-1.5 9h-12z"/><path d="M6 6 5 3H3"/></svg>
                                 Add To Cart
                             </button>
-                            <button class="inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-neutral-700 hover:text-neutral-900 hover:bg-neutral-100" @onclick="() => ShowDetails(product)">
+                            <button class="inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-neutral-700 hover:text-neutral-900 hover:bg-neutral-100" @onclick="() => ShowDetailsAsync(product.Id)">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12Z"/></svg>
                                 See More
                             </button>

--- a/BlazorShop.Presentation/BlazorShop.Web/Pages/Products/LatestProducts.razor.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web/Pages/Products/LatestProducts.razor.cs
@@ -12,9 +12,7 @@
 
     public partial class LatestProducts : IAsyncDisposable
     {
-        private IEnumerable<GetProduct> _products = [];
-
-        private readonly List<GetProduct> _latestProducts = new();
+        private readonly List<GetCatalogProduct> _latestProducts = new();
 
         private List<ProcessCart> _myCarts = [];
 
@@ -26,7 +24,7 @@
         private const int PageSize = 3;
         private int _currentPage = 0;
         private int TotalPages => Math.Max(1, (int)Math.Ceiling((double)_latestProducts.Count / PageSize));
-        private IEnumerable<GetProduct> CurrentPageItems => _latestProducts.Skip(_currentPage * PageSize).Take(PageSize);
+        private IEnumerable<GetCatalogProduct> CurrentPageItems => _latestProducts.Skip(_currentPage * PageSize).Take(PageSize);
 
         private PeriodicTimer? _autoTimer;
         private Task? _autoSlideTask;
@@ -45,18 +43,23 @@
                 _myCarts = JsonSerializer.Deserialize<List<ProcessCart>>(cartJson) ?? new List<ProcessCart>();
             }
 
-            var productsResult = await this.ProductService.GetAllAsync();
+            var productsResult = await this.ProductService.GetCatalogPageAsync(new ProductCatalogQuery
+            {
+                PageNumber = 1,
+                PageSize = 12,
+                SortBy = ProductCatalogSortBy.Newest,
+            });
             if (this.QueryFailureNotifier.TryNotifyFailure(productsResult, "Products"))
             {
-                _products = [];
+                _latestProducts.Clear();
                 return;
             }
 
-            _products = productsResult.Data ?? [];
+            var products = productsResult.Data?.Items ?? [];
 
-            if (_products.Any())
+            if (products.Any())
             {
-                foreach (var p in _products.OrderByDescending(p => p.CreatedOn).Take(12))
+                foreach (var p in products)
                 {
                     _latestProducts.Add(p);
                 }
@@ -121,11 +124,11 @@
             }
         }
 
-        private async Task HandleAddToCart(GetProduct product)
+        private async Task HandleAddToCart(GetCatalogProduct product)
         {
-            if (product.Variants?.Any() == true)
+            if (product.HasVariants)
             {
-                ShowDetails(product);
+                await ShowDetailsAsync(product.Id);
                 return;
             }
 
@@ -209,9 +212,15 @@
             await this.CookieStorageService.SetAsync(Constant.Cart.Name, JsonSerializer.Serialize(_myCarts), 30);
         }
 
-        private void ShowDetails(GetProduct product)
+        private async Task ShowDetailsAsync(Guid productId)
         {
-            this.SelectedProduct = product;
+            var productResult = await this.ProductService.GetByIdAsync(productId);
+            if (this.QueryFailureNotifier.TryNotifyFailure(productResult, "Product details") || productResult.Data is null)
+            {
+                return;
+            }
+
+            this.SelectedProduct = productResult.Data;
             _showModal = true;
         }
 

--- a/BlazorShop.Presentation/BlazorShop.Web/Pages/Products/NewReleases.razor
+++ b/BlazorShop.Presentation/BlazorShop.Web/Pages/Products/NewReleases.razor
@@ -25,7 +25,7 @@
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M6 6h15l-1.5 9h-12z"/><path d="M6 6 5 3H3"/></svg>
                             Add To Cart
                         </button>
-                        <button class="inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-neutral-700 hover:text-neutral-900 hover:bg-neutral-100" @onclick="() => ShowDetails(product)">
+                        <button class="inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-neutral-700 hover:text-neutral-900 hover:bg-neutral-100" @onclick="() => ShowDetailsAsync(product.Id)">
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12Z"/></svg>
                             See More
                         </button>

--- a/BlazorShop.Presentation/BlazorShop.Web/Pages/Products/NewReleases.razor.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web/Pages/Products/NewReleases.razor.cs
@@ -11,7 +11,7 @@
 
     public partial class NewReleases
     {
-        private IEnumerable<GetProduct> _newReleases = [];
+        private IEnumerable<GetCatalogProduct> _newReleases = [];
 
         private bool _isAddingToCart = false;
 
@@ -30,22 +30,27 @@
                 _myCarts = JsonSerializer.Deserialize<List<ProcessCart>>(cartJson) ?? [];
             }
 
-            var allProductsResult = await this.ProductService.GetAllAsync();
+            var allProductsResult = await this.ProductService.GetCatalogPageAsync(new ProductCatalogQuery
+            {
+                PageNumber = 1,
+                PageSize = 60,
+                SortBy = ProductCatalogSortBy.Newest,
+                CreatedAfterUtc = DateTime.UtcNow.AddDays(-7),
+            });
             if (this.QueryFailureNotifier.TryNotifyFailure(allProductsResult, "Products"))
             {
                 _newReleases = [];
                 return;
             }
 
-            var allProducts = allProductsResult.Data ?? [];
-            _newReleases = allProducts.Where(p => p.IsNew).ToList();
+            _newReleases = allProductsResult.Data?.Items ?? [];
         }
 
-        private async Task HandleAddToCart(GetProduct product)
+        private async Task HandleAddToCart(GetCatalogProduct product)
         {
-            if (product.Variants?.Any() == true)
+            if (product.HasVariants)
             {
-                ShowDetails(product);
+                await ShowDetailsAsync(product.Id);
                 return;
             }
 
@@ -129,9 +134,15 @@
             await this.CookieStorageService.SetAsync(Constant.Cart.Name, JsonSerializer.Serialize(_myCarts), 30);
         }
 
-        private void ShowDetails(GetProduct product)
+        private async Task ShowDetailsAsync(Guid productId)
         {
-            this.SelectedProduct = product;
+            var productResult = await this.ProductService.GetByIdAsync(productId);
+            if (this.QueryFailureNotifier.TryNotifyFailure(productResult, "Product details") || productResult.Data is null)
+            {
+                return;
+            }
+
+            this.SelectedProduct = productResult.Data;
             _showModal = true;
         }
 

--- a/BlazorShop.Presentation/BlazorShop.Web/Pages/Public/Deals/TodaysDeals.razor
+++ b/BlazorShop.Presentation/BlazorShop.Web/Pages/Public/Deals/TodaysDeals.razor
@@ -23,7 +23,7 @@
                           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M6 6h15l-1.5 9h-12z"/><path d="M6 6 5 3H3"/></svg>
                           Add to Cart
                       </button>
-                      <button class="inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-neutral-700 hover:text-neutral-900 hover:bg-neutral-100" @onclick="() => ShowDetails(product)">
+                      <button class="inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-neutral-700 hover:text-neutral-900 hover:bg-neutral-100" @onclick="() => ShowDetailsAsync(product.Id)">
                           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12Z"/></svg>
                           See More
                       </button>

--- a/BlazorShop.Presentation/BlazorShop.Web/Pages/Public/Deals/TodaysDeals.razor.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web/Pages/Public/Deals/TodaysDeals.razor.cs
@@ -11,7 +11,7 @@
 
     public partial class TodaysDeals : IAsyncDisposable
     {
-        private IEnumerable<GetProduct> _todaysDeals = [];
+        private IEnumerable<GetCatalogProduct> _todaysDeals = [];
         private List<ProcessCart> _myCarts = new();
         private bool _isAddingToCart = false;
         private bool _showModal = false;
@@ -21,14 +21,19 @@
 
         protected override async Task OnInitializedAsync()
         {
-            var allResult = await this.ProductService.GetAllAsync();
+            var allResult = await this.ProductService.GetCatalogPageAsync(new ProductCatalogQuery
+            {
+                PageNumber = 1,
+                PageSize = 100,
+                SortBy = ProductCatalogSortBy.Newest,
+            });
             if (this.QueryFailureNotifier.TryNotifyFailure(allResult, "Products"))
             {
                 _todaysDeals = [];
             }
             else
             {
-                _todaysDeals = (allResult.Data ?? []).ToList();
+                _todaysDeals = allResult.Data?.Items ?? [];
             }
 
             var cartJson = await this.CookieStorageService.GetAsync(Constant.Cart.Name);
@@ -38,11 +43,11 @@
             }
         }
 
-        private async Task HandleAddToCart(GetProduct product)
+        private async Task HandleAddToCart(GetCatalogProduct product)
         {
-            if (product.Variants?.Any() == true)
+            if (product.HasVariants)
             {
-                ShowDetails(product);
+                await ShowDetailsAsync(product.Id);
                 return;
             }
 
@@ -126,9 +131,15 @@
             await this.CookieStorageService.SetAsync(Constant.Cart.Name, JsonSerializer.Serialize(_myCarts), 30);
         }
 
-        private void ShowDetails(GetProduct product)
+        private async Task ShowDetailsAsync(Guid productId)
         {
-            this.SelectedProduct = product;
+            var productResult = await this.ProductService.GetByIdAsync(productId);
+            if (this.QueryFailureNotifier.TryNotifyFailure(productResult, "Product details") || productResult.Data is null)
+            {
+                return;
+            }
+
+            this.SelectedProduct = productResult.Data;
             _showModal = true;
         }
 

--- a/BlazorShop.Presentation/BlazorShop.Web/Program.cs
+++ b/BlazorShop.Presentation/BlazorShop.Web/Program.cs
@@ -38,6 +38,7 @@ namespace BlazorShop.Web
             builder.Services.AddScoped<ICategoryService, CategoryService>();
             builder.Services.AddScoped<IAuthenticationService, AuthenticationService>();
             builder.Services.AddScoped<AuthenticationStateProvider, CustomAuthStateProvider>();
+            builder.Services.AddScoped<IAuthenticationStateNotifier, AuthenticationStateNotifier>();
             builder.Services.AddScoped<BrowserCredentialsHandler>();
             builder.Services.AddScoped<RefreshTokenHandler>();
             builder.Services.AddHttpClient(

--- a/BlazorShop.Presentation/BlazorShop.Web/package-lock.json
+++ b/BlazorShop.Presentation/BlazorShop.Web/package-lock.json
@@ -245,9 +245,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -311,9 +311,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001735",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001735.tgz",
-      "integrity": "sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "dev": true,
       "funding": [
         {
@@ -582,9 +582,10 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -785,13 +786,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -937,9 +938,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1639,9 +1640,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1649,6 +1650,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/BlazorShop.Tests/Application/Services/ProductServiceTests.cs
+++ b/BlazorShop.Tests/Application/Services/ProductServiceTests.cs
@@ -126,6 +126,64 @@
             this._mockMapper.Verify(mapper => mapper.Map<GetProduct>(It.IsAny<Product>()), Times.Never);
         }
 
+        [Fact]
+        public async Task GetCatalogPageAsync_WhenCatalogItemsExist_ShouldReturnMappedPage()
+        {
+            var query = new ProductCatalogQuery { PageNumber = 1, PageSize = 2, SortBy = ProductCatalogSortBy.Newest };
+            var catalogItems = new List<CatalogProductReadModel>
+            {
+                new CatalogProductReadModel
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Catalog Product 1",
+                    Description = "Description 1",
+                    Price = 20m,
+                    Image = "/img/1.png",
+                    CategoryId = Guid.NewGuid(),
+                    CreatedOn = DateTime.UtcNow,
+                    HasVariants = true,
+                },
+                new CatalogProductReadModel
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Catalog Product 2",
+                    Description = "Description 2",
+                    Price = 30m,
+                    Image = "/img/2.png",
+                    CategoryId = Guid.NewGuid(),
+                    CreatedOn = DateTime.UtcNow.AddDays(-1),
+                    HasVariants = false,
+                }
+            };
+            var pagedCatalog = new PagedResult<CatalogProductReadModel>
+            {
+                Items = catalogItems,
+                PageNumber = 1,
+                PageSize = 2,
+                TotalCount = 5,
+            };
+            var mappedItems = new List<GetCatalogProduct>
+            {
+                new GetCatalogProduct { Id = catalogItems[0].Id, Name = "Catalog Product 1", HasVariants = true },
+                new GetCatalogProduct { Id = catalogItems[1].Id, Name = "Catalog Product 2", HasVariants = false },
+            };
+
+            this._mockProductReadRepository
+                .Setup(repo => repo.GetCatalogPageAsync(query))
+                .ReturnsAsync(pagedCatalog);
+            this._mockMapper
+                .Setup(mapper => mapper.Map<IReadOnlyList<GetCatalogProduct>>(catalogItems))
+                .Returns(mappedItems);
+
+            var result = await this._productService.GetCatalogPageAsync(query);
+
+            Assert.Equal(5, result.TotalCount);
+            Assert.Equal(2, result.Items.Count);
+            Assert.Equal(mappedItems, result.Items);
+            this._mockProductReadRepository.Verify(repo => repo.GetCatalogPageAsync(query), Times.Once);
+            this._mockMapper.Verify(mapper => mapper.Map<IReadOnlyList<GetCatalogProduct>>(catalogItems), Times.Once);
+        }
+
 
         [Fact]
         public async Task AddAsync_WhenProductIsAdded_ShouldReturnSuccessResponse()

--- a/BlazorShop.Tests/BlazorShop.Tests.csproj
+++ b/BlazorShop.Tests/BlazorShop.Tests.csproj
@@ -30,6 +30,7 @@
     <ProjectReference Include="..\BlazorShop.Application\BlazorShop.Application.csproj" />
     <ProjectReference Include="..\BlazorShop.Infrastructure\BlazorShop.Infrastructure.csproj" />
     <ProjectReference Include="..\BlazorShop.Presentation\BlazorShop.API\BlazorShop.API.csproj" />
+    <ProjectReference Include="..\BlazorShop.Presentation\BlazorShop.Web\BlazorShop.Web.csproj" />
     <ProjectReference Include="..\BlazorShop.Presentation\BlazorShop.Web.Shared\BlazorShop.Web.Shared.csproj" />
   </ItemGroup>
 

--- a/BlazorShop.Tests/Infrastructure/Configuration/EmailSettingsOptionsValidatorTests.cs
+++ b/BlazorShop.Tests/Infrastructure/Configuration/EmailSettingsOptionsValidatorTests.cs
@@ -1,0 +1,70 @@
+namespace BlazorShop.Tests.Infrastructure.Configuration
+{
+    using BlazorShop.Application.DTOs;
+    using BlazorShop.Infrastructure.Configuration;
+
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Options;
+
+    using Moq;
+
+    using Xunit;
+
+    public class EmailSettingsOptionsValidatorTests
+    {
+        [Fact]
+        public void Validate_WhenProductionAndRequiredValuesAreMissing_ReturnsFailures()
+        {
+            var validator = CreateValidator(Environments.Production);
+
+            var result = validator.Validate(
+                name: null,
+                new EmailSettings
+                {
+                    From = "<required-sender-address>",
+                    SmtpServer = "",
+                    Port = 0,
+                    Username = "<required-smtp-username>",
+                    Password = ""
+                });
+
+            var failures = Assert.IsAssignableFrom<IEnumerable<string>>(result.Failures);
+
+            Assert.False(result.Succeeded);
+            Assert.Contains(failures, failure => failure.Contains("EmailSettings:From", StringComparison.Ordinal));
+            Assert.Contains(failures, failure => failure.Contains("EmailSettings:SmtpServer", StringComparison.Ordinal));
+            Assert.Contains(failures, failure => failure.Contains("EmailSettings:Port", StringComparison.Ordinal));
+            Assert.Contains(failures, failure => failure.Contains("EmailSettings:Username", StringComparison.Ordinal));
+            Assert.Contains(failures, failure => failure.Contains("EmailSettings:Password", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void Validate_WhenDevelopment_AllowsPlaceholderValues()
+        {
+            var validator = CreateValidator(Environments.Development);
+
+            var result = validator.Validate(
+                name: null,
+                new EmailSettings
+                {
+                    From = "<required-sender-address>",
+                    SmtpServer = "<required-smtp-host>",
+                    Port = 587,
+                    Username = "<required-smtp-username>",
+                    Password = "<required-smtp-password>"
+                });
+
+            Assert.True(result.Succeeded);
+        }
+
+        private static EmailSettingsOptionsValidator CreateValidator(string environmentName)
+        {
+            var hostEnvironment = new Mock<IHostEnvironment>();
+            hostEnvironment
+                .SetupGet(environment => environment.EnvironmentName)
+                .Returns(environmentName);
+
+            return new EmailSettingsOptionsValidator(hostEnvironment.Object);
+        }
+    }
+}

--- a/BlazorShop.Tests/Infrastructure/Repositories/ProductReadRepositoryTests.cs
+++ b/BlazorShop.Tests/Infrastructure/Repositories/ProductReadRepositoryTests.cs
@@ -1,0 +1,170 @@
+namespace BlazorShop.Tests.Infrastructure.Repositories
+{
+    using BlazorShop.Domain.Contracts;
+    using BlazorShop.Domain.Entities;
+    using BlazorShop.Infrastructure.Data;
+    using BlazorShop.Infrastructure.Repositories;
+
+    using Microsoft.EntityFrameworkCore;
+
+    using Xunit;
+
+    public class ProductReadRepositoryTests
+    {
+        [Fact]
+        public async Task GetCatalogPageAsync_ReturnsRequestedPage()
+        {
+            await using var context = CreateContext();
+            var categoryId = Guid.NewGuid();
+            await SeedProductsAsync(context, categoryId, Guid.NewGuid());
+            var repository = new ProductReadRepository(context);
+
+            var result = await repository.GetCatalogPageAsync(new ProductCatalogQuery
+            {
+                PageNumber = 2,
+                PageSize = 2,
+                SortBy = ProductCatalogSortBy.Newest,
+            });
+
+            Assert.Equal(2, result.PageNumber);
+            Assert.Equal(2, result.PageSize);
+            Assert.Equal(5, result.TotalCount);
+            Assert.Equal(2, result.Items.Count);
+            Assert.Equal("Product 3", result.Items[0].Name);
+            Assert.Equal("Product 2", result.Items[1].Name);
+        }
+
+        [Fact]
+        public async Task GetCatalogPageAsync_FiltersByCategory()
+        {
+            await using var context = CreateContext();
+            var featuredCategoryId = Guid.NewGuid();
+            var otherCategoryId = Guid.NewGuid();
+            await SeedProductsAsync(context, featuredCategoryId, otherCategoryId);
+            var repository = new ProductReadRepository(context);
+
+            var result = await repository.GetCatalogPageAsync(new ProductCatalogQuery
+            {
+                PageNumber = 1,
+                PageSize = 10,
+                CategoryId = featuredCategoryId,
+            });
+
+            Assert.Equal(3, result.TotalCount);
+            Assert.Equal(3, result.Items.Count);
+            Assert.All(result.Items, item => Assert.Equal(featuredCategoryId, item.CategoryId));
+        }
+
+        [Fact]
+        public async Task GetProductDetailsByIdAsync_ReturnsRequiredCategoryAndVariants()
+        {
+            await using var context = CreateContext();
+            var categoryId = Guid.NewGuid();
+            await SeedProductsAsync(context, categoryId, Guid.NewGuid());
+            var productId = await context.Products
+                .Where(product => product.Name == "Product 5")
+                .Select(product => product.Id)
+                .SingleAsync();
+            var repository = new ProductReadRepository(context);
+
+            var result = await repository.GetProductDetailsByIdAsync(productId);
+
+            Assert.NotNull(result);
+            Assert.NotNull(result!.Category);
+            Assert.Equal("Featured", result.Category!.Name);
+            Assert.Single(result.Variants);
+            Assert.Equal("42", result.Variants.Single().SizeValue);
+            Assert.Equal(25m, result.Variants.Single().Price);
+        }
+
+        private static AppDbContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<AppDbContext>()
+                .UseInMemoryDatabase($"product-read-repository-tests-{Guid.NewGuid()}")
+                .Options;
+
+            return new AppDbContext(options);
+        }
+
+        private static async Task SeedProductsAsync(AppDbContext context, Guid featuredCategoryId, Guid otherCategoryId)
+        {
+            context.Categories.AddRange(
+                new Category { Id = featuredCategoryId, Name = "Featured" },
+                new Category { Id = otherCategoryId, Name = "Other" });
+
+            var product1 = new Product
+            {
+                Id = Guid.NewGuid(),
+                Name = "Product 1",
+                Description = "Desc 1",
+                Image = "/img/1.png",
+                Price = 10m,
+                Quantity = 10,
+                CategoryId = featuredCategoryId,
+                CreatedOn = new DateTime(2026, 4, 10, 0, 0, 0, DateTimeKind.Utc)
+            };
+
+            var product2 = new Product
+            {
+                Id = Guid.NewGuid(),
+                Name = "Product 2",
+                Description = "Desc 2",
+                Image = "/img/2.png",
+                Price = 11m,
+                Quantity = 9,
+                CategoryId = otherCategoryId,
+                CreatedOn = new DateTime(2026, 4, 11, 0, 0, 0, DateTimeKind.Utc)
+            };
+
+            var product3 = new Product
+            {
+                Id = Guid.NewGuid(),
+                Name = "Product 3",
+                Description = "Desc 3",
+                Image = "/img/3.png",
+                Price = 12m,
+                Quantity = 8,
+                CategoryId = featuredCategoryId,
+                CreatedOn = new DateTime(2026, 4, 12, 0, 0, 0, DateTimeKind.Utc)
+            };
+
+            var product4 = new Product
+            {
+                Id = Guid.NewGuid(),
+                Name = "Product 4",
+                Description = "Desc 4",
+                Image = "/img/4.png",
+                Price = 13m,
+                Quantity = 7,
+                CategoryId = otherCategoryId,
+                CreatedOn = new DateTime(2026, 4, 13, 0, 0, 0, DateTimeKind.Utc)
+            };
+
+            var product5 = new Product
+            {
+                Id = Guid.NewGuid(),
+                Name = "Product 5",
+                Description = "Desc 5",
+                Image = "/img/5.png",
+                Price = 14m,
+                Quantity = 6,
+                CategoryId = featuredCategoryId,
+                CreatedOn = new DateTime(2026, 4, 14, 0, 0, 0, DateTimeKind.Utc)
+            };
+
+            context.Products.AddRange(product1, product2, product3, product4, product5);
+            context.ProductVariants.Add(new ProductVariant
+            {
+                Id = Guid.NewGuid(),
+                ProductId = product5.Id,
+                SizeScale = SizeScale.ShoesEU,
+                SizeValue = "42",
+                Price = 25m,
+                Stock = 3,
+                IsDefault = true,
+            });
+
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/BlazorShop.Tests/Presentation/API/Controllers/ProductControllerTests.cs
+++ b/BlazorShop.Tests/Presentation/API/Controllers/ProductControllerTests.cs
@@ -1,0 +1,54 @@
+namespace BlazorShop.Tests.Presentation.API.Controllers
+{
+    using BlazorShop.API.Controllers;
+    using BlazorShop.Application.DTOs.Product;
+    using BlazorShop.Application.Services.Contracts;
+    using BlazorShop.Domain.Contracts;
+
+    using Microsoft.AspNetCore.Mvc;
+
+    using Moq;
+
+    using Xunit;
+
+    public class ProductControllerTests
+    {
+        [Fact]
+        public async Task GetCatalog_ReturnsOkWithPagedCatalog()
+        {
+            var productService = new Mock<IProductService>();
+            var page = new PagedResult<GetCatalogProduct>
+            {
+                Items =
+                [
+                    new GetCatalogProduct
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = "Catalog Product",
+                        Description = "Catalog Description",
+                        Price = 20m,
+                        Image = "/img/catalog.png",
+                        CreatedOn = DateTime.UtcNow,
+                        CategoryId = Guid.NewGuid(),
+                        HasVariants = false,
+                    }
+                ],
+                PageNumber = 1,
+                PageSize = 12,
+                TotalCount = 1,
+            };
+
+            productService
+                .Setup(service => service.GetCatalogPageAsync(It.IsAny<ProductCatalogQuery>()))
+                .ReturnsAsync(page);
+
+            var controller = new ProductController(productService.Object);
+
+            var result = await controller.GetCatalog(new ProductCatalogQuery { PageNumber = 1, PageSize = 12 });
+
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var payload = Assert.IsType<PagedResult<GetCatalogProduct>>(okResult.Value);
+            Assert.Single(payload.Items);
+        }
+    }
+}

--- a/BlazorShop.Tests/Presentation/Authentication/RefreshTokenHandlerTests.cs
+++ b/BlazorShop.Tests/Presentation/Authentication/RefreshTokenHandlerTests.cs
@@ -1,0 +1,125 @@
+namespace BlazorShop.Tests.Presentation.Authentication
+{
+    using System.Net;
+    using System.Net.Http.Headers;
+
+    using BlazorShop.Web.Authentication.Providers;
+    using BlazorShop.Web.Shared;
+    using BlazorShop.Web.Shared.Helper.Contracts;
+    using BlazorShop.Web.Shared.Models;
+    using BlazorShop.Web.Shared.Services.Contracts;
+
+    using Moq;
+
+    using Xunit;
+
+    public class RefreshTokenHandlerTests
+    {
+        [Fact]
+        public async Task SendAsync_WhenRefreshSucceeds_RetriesRequestWithNewToken_AndNotifiesAuthState()
+        {
+            const string refreshedToken = "refreshed-token";
+
+            var tokenService = new Mock<ITokenService>();
+            tokenService
+                .Setup(service => service.StoreJwtTokenAsync(Constant.TokenStorage.Key, refreshedToken))
+                .Returns(Task.CompletedTask);
+
+            var authenticationService = new Mock<IAuthenticationService>();
+            authenticationService
+                .Setup(service => service.ReviveToken())
+                .ReturnsAsync(new LoginResponse(true, "Token revived successfully.", refreshedToken));
+
+            var authStateNotifier = new Mock<IAuthenticationStateNotifier>();
+            var innerHandler = new RecordingHandler(HttpStatusCode.Unauthorized, HttpStatusCode.OK);
+
+            using var client = CreateClient(tokenService.Object, authenticationService.Object, authStateNotifier.Object, innerHandler);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://example.test/api/orders");
+            request.Headers.Authorization = new AuthenticationHeaderValue(Constant.Authentication.Type, "expired-token");
+
+            var response = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(2, innerHandler.CallCount);
+            Assert.Equal("Bearer expired-token", innerHandler.AuthorizationHeaders[0]);
+            Assert.Equal($"Bearer {refreshedToken}", innerHandler.AuthorizationHeaders[1]);
+            tokenService.Verify(service => service.StoreJwtTokenAsync(Constant.TokenStorage.Key, refreshedToken), Times.Once);
+            tokenService.Verify(service => service.RemoveJwtTokenAsync(It.IsAny<string>()), Times.Never);
+            authStateNotifier.Verify(notifier => notifier.NotifyAuthenticationState(), Times.Once);
+        }
+
+        [Fact]
+        public async Task SendAsync_WhenRefreshFails_ClearsToken_AndNotifiesAuthStateWithoutRetry()
+        {
+            var tokenService = new Mock<ITokenService>();
+            tokenService
+                .Setup(service => service.RemoveJwtTokenAsync(Constant.TokenStorage.Key))
+                .Returns(Task.CompletedTask);
+
+            var authenticationService = new Mock<IAuthenticationService>();
+            authenticationService
+                .Setup(service => service.ReviveToken())
+                .ReturnsAsync(new LoginResponse(Message: "Invalid token."));
+
+            var authStateNotifier = new Mock<IAuthenticationStateNotifier>();
+            var innerHandler = new RecordingHandler(HttpStatusCode.Unauthorized);
+
+            using var client = CreateClient(tokenService.Object, authenticationService.Object, authStateNotifier.Object, innerHandler);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://example.test/api/orders");
+            request.Headers.Authorization = new AuthenticationHeaderValue(Constant.Authentication.Type, "expired-token");
+
+            var response = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal(1, innerHandler.CallCount);
+            tokenService.Verify(service => service.StoreJwtTokenAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            tokenService.Verify(service => service.RemoveJwtTokenAsync(Constant.TokenStorage.Key), Times.Once);
+            authStateNotifier.Verify(notifier => notifier.NotifyAuthenticationState(), Times.Once);
+        }
+
+        private static HttpClient CreateClient(
+            ITokenService tokenService,
+            IAuthenticationService authenticationService,
+            IAuthenticationStateNotifier authStateNotifier,
+            RecordingHandler innerHandler)
+        {
+            var refreshHandler = new RefreshTokenHandler(tokenService, authenticationService, authStateNotifier)
+            {
+                InnerHandler = innerHandler,
+            };
+
+            return new HttpClient(refreshHandler);
+        }
+
+        private sealed class RecordingHandler : HttpMessageHandler
+        {
+            private readonly Queue<HttpStatusCode> _responses;
+
+            public RecordingHandler(params HttpStatusCode[] responses)
+            {
+                _responses = new Queue<HttpStatusCode>(responses);
+            }
+
+            public int CallCount { get; private set; }
+
+            public List<string?> AuthorizationHeaders { get; } = [];
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                CallCount++;
+                AuthorizationHeaders.Add(request.Headers.Authorization?.ToString());
+
+                var statusCode = _responses.Count > 0
+                    ? _responses.Dequeue()
+                    : HttpStatusCode.OK;
+
+                return Task.FromResult(new HttpResponseMessage(statusCode)
+                {
+                    RequestMessage = request,
+                });
+            }
+        }
+    }
+}

--- a/BlazorShop.Tests/Presentation/Services/ProductServiceTests.cs
+++ b/BlazorShop.Tests/Presentation/Services/ProductServiceTests.cs
@@ -102,6 +102,56 @@ namespace BlazorShop.Tests.Presentation.Services
         }
 
         [Fact]
+        public async Task GetCatalogPageAsync_ShouldReturnPagedCatalog_WhenApiCallIsSuccessful()
+        {
+            var client = new HttpClient();
+            this._httpClientHelperMock.Setup(helper => helper.GetPublicClient()).Returns(client);
+
+            var apiCallResult = new HttpResponseMessage(HttpStatusCode.OK);
+            this._apiCallHelperMock
+                .Setup(helper => helper.ApiCallTypeCall<Unit>(It.IsAny<ApiCall>()))
+                .ReturnsAsync(apiCallResult);
+
+            var catalogPage = new PagedResult<GetCatalogProduct>
+            {
+                Items =
+                [
+                    new GetCatalogProduct
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = "Catalog Product",
+                        Description = "Description",
+                        Price = 25m,
+                        Image = "/img/catalog.png",
+                        CreatedOn = DateTime.UtcNow,
+                        CategoryId = Guid.NewGuid(),
+                        HasVariants = true,
+                    }
+                ],
+                PageNumber = 1,
+                PageSize = 8,
+                TotalCount = 1,
+            };
+
+            this._apiCallHelperMock
+                .Setup(helper => helper.GetQueryResult<PagedResult<GetCatalogProduct>>(apiCallResult, It.IsAny<string>()))
+                .ReturnsAsync(QueryResult<PagedResult<GetCatalogProduct>>.Succeeded(catalogPage));
+
+            var result = await this._productService.GetCatalogPageAsync(new ProductCatalogQuery
+            {
+                PageNumber = 1,
+                PageSize = 8,
+                SearchTerm = "Catalog",
+                SortBy = ProductCatalogSortBy.NameAscending,
+            });
+
+            Assert.True(result.Success);
+            Assert.NotNull(result.Data);
+            Assert.Single(result.Data!.Items);
+            Assert.Equal("Catalog Product", result.Data.Items[0].Name);
+        }
+
+        [Fact]
         public async Task AddAsync_ShouldReturnServiceResponse_WhenApiCallIsSuccessful()
         {
             // Arrange

--- a/compose.production.yml
+++ b/compose.production.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:16.13-alpine3.23
     environment:
       POSTGRES_DB: blazorshop
       POSTGRES_USER: blazorshop
@@ -27,11 +27,17 @@ services:
       Jwt__Audience: ${BLAZORSHOP_PUBLIC_BASE_URL:-http://localhost:8080}
       ClientApp__BaseUrl: ${BLAZORSHOP_PUBLIC_BASE_URL:-http://localhost:8080}
       Stripe__SecretKey: ${BLAZORSHOP_STRIPE_SECRET_KEY}
-      EmailSettings__Username: ${BLAZORSHOP_EMAIL_USERNAME}
-      EmailSettings__Password: ${BLAZORSHOP_EMAIL_PASSWORD}
+      EmailSettings__From: "${BLAZORSHOP_EMAIL_FROM:?BLAZORSHOP_EMAIL_FROM is required}"
+      EmailSettings__DisplayName: ${BLAZORSHOP_EMAIL_DISPLAY_NAME:-BlazorShop}
+      EmailSettings__SmtpServer: "${BLAZORSHOP_EMAIL_SMTP_SERVER:?BLAZORSHOP_EMAIL_SMTP_SERVER is required}"
+      EmailSettings__Port: ${BLAZORSHOP_EMAIL_SMTP_PORT:-587}
+      EmailSettings__UseSsl: ${BLAZORSHOP_EMAIL_USE_SSL:-true}
+      EmailSettings__Username: "${BLAZORSHOP_EMAIL_USERNAME:?BLAZORSHOP_EMAIL_USERNAME is required}"
+      EmailSettings__Password: "${BLAZORSHOP_EMAIL_PASSWORD:?BLAZORSHOP_EMAIL_PASSWORD is required}"
       Runtime__Cors__AllowedOrigins__0: ${BLAZORSHOP_PUBLIC_BASE_URL:-http://localhost:8080}
       Runtime__ForwardedHeaders__Enabled: true
       Runtime__ForwardedHeaders__KnownProxies__0: 172.30.0.10
+      Runtime__ForwardedHeaders__ForwardLimit: 1
       Runtime__Health__ExposeInProduction: false
       Runtime__Security__EnableHsts: false
       Runtime__Security__EnableHttpsRedirection: false


### PR DESCRIPTION
Add paged product catalog API and frontend integration

- Implement paged product catalog API with filtering, sorting, and pagination
- Add new DTOs and models for catalog queries and results
- Update product controller with /api/product/catalog endpoint
- Refactor frontend to use paged catalog API for product lists and search
- Fetch product details on demand in cart and detail views
- Add tests for catalog API, repository, controller, and frontend service
- Enforce email settings validation in production with new validator and tests
- Update Dockerfiles and compose for improved email config and image args
- Remove unused code from header/layout; update npm dependencies