### PR TITLE
Update .NET setup to use global.json in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 10.0.x
+          global-json-file: global.json
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Update .NET setup to use global.json in CI workflow

Replaced explicit dotnet-version with global-json-file in the GitHub Actions workflow to determine the .NET version from global.json, improving version management consistency.