### PR TITLE
Update OpenTelemetry packages and add absolute path tests

### DIFF
--- a/BlazorShop.ServiceDefaults/BlazorShop.ServiceDefaults.csproj
+++ b/BlazorShop.ServiceDefaults/BlazorShop.ServiceDefaults.csproj
@@ -12,11 +12,11 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
 
 </Project>

--- a/BlazorShop.Tests/Presentation/Authentication/AuthSmokeSettingsTests.cs
+++ b/BlazorShop.Tests/Presentation/Authentication/AuthSmokeSettingsTests.cs
@@ -34,6 +34,22 @@ namespace BlazorShop.Tests.Presentation.Authentication
         }
 
         [Fact]
+        public void ResolveClientAppUrl_WhenRoutePathIsAbsolute_Throws()
+        {
+            var settings = AuthSmokeSettings.FromLookup(name => name switch
+            {
+                AuthSmokeSettings.ApiBaseUrlEnvironmentVariableName => "https://api.example.com",
+                AuthSmokeSettings.StorefrontBaseUrlEnvironmentVariableName => "https://shop.example.com",
+                AuthSmokeSettings.ClientAppBaseUrlEnvironmentVariableName => "https://account.example.com",
+                _ => null,
+            });
+
+            var exception = Assert.Throws<InvalidOperationException>(() => settings.ResolveClientAppUrl("file:///account/checkout"));
+
+            Assert.Contains("route path", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void FromLookup_WhenApiBaseAlreadyTargetsAuthenticationRoot_PreservesIt()
         {
             var settings = AuthSmokeSettings.FromLookup(name => name switch

--- a/BlazorShop.Tests/Presentation/Storefront/StorefrontSeoSmokeSettingsTests.cs
+++ b/BlazorShop.Tests/Presentation/Storefront/StorefrontSeoSmokeSettingsTests.cs
@@ -32,6 +32,19 @@ namespace BlazorShop.Tests.Presentation.Storefront
         }
 
         [Fact]
+        public void FromLookup_WhenRoutePathIsAbsolute_Throws()
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() => StorefrontSeoSmokeSettings.FromLookup(name => name switch
+            {
+                StorefrontSeoSmokeSettings.BaseUrlEnvironmentVariableName => "https://shop.example.com",
+                StorefrontSeoSmokeSettings.CategoryPathEnvironmentVariableName => "https://shop.example.com/category/sneakers",
+                _ => null,
+            }));
+
+            Assert.Contains(StorefrontSeoSmokeSettings.CategoryPathEnvironmentVariableName, exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void FromLookup_WhenRedirectPairIsBlank_DisablesRedirectSmokeOnly()
         {
             var settings = StorefrontSeoSmokeSettings.FromLookup(name => name switch


### PR DESCRIPTION
Update OpenTelemetry packages and add absolute path tests

Updated OpenTelemetry NuGet packages to 1.15.x versions. Added tests to ensure exceptions are thrown for absolute route paths in AuthSmokeSettings and StorefrontSeoSmokeSettings. Minor formatting improvements in test files.