### PR TITLE
Improve URL and path validation in test suite

### DIFF
--- a/BlazorShop.Tests/Presentation/Authentication/Support/AuthSmokeSettings.cs
+++ b/BlazorShop.Tests/Presentation/Authentication/Support/AuthSmokeSettings.cs
@@ -168,12 +168,13 @@ namespace BlazorShop.Tests.Presentation.Authentication
                 throw new ArgumentException("Value cannot be null or whitespace.", parameterName);
             }
 
-            if (Uri.TryCreate(actionPath.Trim(), UriKind.Absolute, out _))
+            var trimmedValue = actionPath.Trim();
+            if (HasExplicitUriScheme(trimmedValue) || trimmedValue.StartsWith("//", StringComparison.Ordinal))
             {
                 throw new InvalidOperationException($"{parameterName} must be a relative auth action segment.");
             }
 
-            return actionPath.Trim().Trim('/');
+            return trimmedValue.Trim('/');
         }
 
         private static bool ParseBoolean(string? rawValue, string environmentVariableName)
@@ -198,20 +199,33 @@ namespace BlazorShop.Tests.Presentation.Authentication
                 throw new ArgumentException("Value cannot be null or whitespace.", parameterName);
             }
 
-            if (Uri.TryCreate(routePath.Trim(), UriKind.Absolute, out _))
+            var normalizedPath = routePath.Trim();
+            if (HasExplicitUriScheme(normalizedPath) || normalizedPath.StartsWith("//", StringComparison.Ordinal))
             {
                 throw new InvalidOperationException($"{parameterName} must be a relative route path.");
             }
 
-            var normalizedPath = routePath.Trim();
             if (!normalizedPath.StartsWith("/", StringComparison.Ordinal))
             {
-                normalizedPath = $"/{normalizedPath}";
+                throw new InvalidOperationException($"{parameterName} must begin with '/'.");
             }
 
             return normalizedPath == "/"
                 ? string.Empty
                 : normalizedPath.TrimStart('/');
+        }
+
+        private static bool HasExplicitUriScheme(string value)
+        {
+            var trimmedValue = value.Trim();
+            var colonIndex = trimmedValue.IndexOf(':');
+            if (colonIndex <= 0)
+            {
+                return false;
+            }
+
+            var firstPathSeparatorIndex = trimmedValue.IndexOfAny(['/', '?', '#']);
+            return firstPathSeparatorIndex < 0 || colonIndex < firstPathSeparatorIndex;
         }
     }
 }

--- a/BlazorShop.Tests/Presentation/Storefront/StorefrontCartFlowTests.cs
+++ b/BlazorShop.Tests/Presentation/Storefront/StorefrontCartFlowTests.cs
@@ -188,7 +188,7 @@ namespace BlazorShop.Tests.Presentation.Storefront
                     return _baseUrl;
                 }
 
-                if (Uri.TryCreate(relativeOrAbsoluteUrl.Trim(), UriKind.Absolute, out var absoluteUri))
+                if (TryCreateHttpAbsoluteUri(relativeOrAbsoluteUrl, out var absoluteUri))
                 {
                     return absoluteUri.ToString();
                 }
@@ -198,6 +198,12 @@ namespace BlazorShop.Tests.Presentation.Storefront
                     : $"/{relativeOrAbsoluteUrl}";
 
                 return new Uri(new Uri(_baseUrl, UriKind.Absolute), relativePath).ToString();
+            }
+
+            private static bool TryCreateHttpAbsoluteUri(string value, out Uri uri)
+            {
+                return Uri.TryCreate(value.Trim(), UriKind.Absolute, out uri!)
+                    && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
             }
         }
     }

--- a/BlazorShop.Tests/Presentation/Storefront/StorefrontSeoComposerTests.cs
+++ b/BlazorShop.Tests/Presentation/Storefront/StorefrontSeoComposerTests.cs
@@ -140,9 +140,18 @@ namespace BlazorShop.Tests.Presentation.Storefront
                     return null;
                 }
 
-                return Uri.TryCreate(relativeOrAbsoluteUrl, UriKind.Absolute, out var absoluteUri)
-                    ? absoluteUri.ToString()
-                    : new Uri(new Uri(ResolveBaseUrl(configuredBaseUrl)!, UriKind.Absolute), relativeOrAbsoluteUrl).ToString();
+                if (TryCreateHttpAbsoluteUri(relativeOrAbsoluteUrl, out var absoluteUri))
+                {
+                    return absoluteUri.ToString();
+                }
+
+                return new Uri(new Uri(ResolveBaseUrl(configuredBaseUrl)!, UriKind.Absolute), relativeOrAbsoluteUrl).ToString();
+            }
+
+            private static bool TryCreateHttpAbsoluteUri(string value, out Uri uri)
+            {
+                return Uri.TryCreate(value.Trim(), UriKind.Absolute, out uri!)
+                    && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
             }
         }
     }

--- a/BlazorShop.Tests/Presentation/Storefront/StorefrontStructuredDataComposerTests.cs
+++ b/BlazorShop.Tests/Presentation/Storefront/StorefrontStructuredDataComposerTests.cs
@@ -165,9 +165,12 @@ namespace BlazorShop.Tests.Presentation.Storefront
                     return null;
                 }
 
-                return Uri.TryCreate(relativeOrAbsoluteUrl, UriKind.Absolute, out var absoluteUri)
-                    ? absoluteUri.ToString()
-                    : new Uri(new Uri(ResolveBaseUrl(configuredBaseUrl)!, UriKind.Absolute), relativeOrAbsoluteUrl).ToString();
+                if (TryCreateHttpAbsoluteUri(relativeOrAbsoluteUrl, out var absoluteUri))
+                {
+                    return absoluteUri.ToString();
+                }
+
+                return new Uri(new Uri(ResolveBaseUrl(configuredBaseUrl)!, UriKind.Absolute), relativeOrAbsoluteUrl).ToString();
             }
 
             private static string? NormalizeAbsoluteUrl(string? candidate)
@@ -190,6 +193,12 @@ namespace BlazorShop.Tests.Presentation.Storefront
                 };
 
                 return builder.Uri.ToString();
+            }
+
+            private static bool TryCreateHttpAbsoluteUri(string value, out Uri uri)
+            {
+                return Uri.TryCreate(value.Trim(), UriKind.Absolute, out uri!)
+                    && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
             }
         }
     }

--- a/BlazorShop.Tests/Presentation/Storefront/Support/StorefrontSeoSmokeSettings.cs
+++ b/BlazorShop.Tests/Presentation/Storefront/Support/StorefrontSeoSmokeSettings.cs
@@ -105,7 +105,7 @@ namespace BlazorShop.Tests.Presentation.Storefront
             var productPath = ReadRequiredRoutePath(getValue, ProductPathEnvironmentVariableName, StorefrontRoutes.Product("metro-runner"));
             var missingPath = ReadRequiredRoutePath(getValue, MissingPathEnvironmentVariableName, StorefrontRoutes.Product("missing-product"));
             var redirectSourcePath = ReadOptionalRoutePath(getValue, RedirectSourcePathEnvironmentVariableName, DefaultRedirectSourcePath);
-            var redirectTargetPath = ReadOptionalRouteOrAbsoluteUrl(getValue, RedirectTargetPathEnvironmentVariableName, DefaultRedirectTargetPath);
+            var redirectTargetPath = ReadOptionalRoutePath(getValue, RedirectTargetPathEnvironmentVariableName, DefaultRedirectTargetPath);
             var redirectExpectedStatusCode = ReadRedirectStatusCode(getValue);
 
             if (string.IsNullOrWhiteSpace(redirectSourcePath) != string.IsNullOrWhiteSpace(redirectTargetPath))
@@ -142,29 +142,12 @@ namespace BlazorShop.Tests.Presentation.Storefront
         public string ResolveExpectedCanonicalUrl(string routePathOrAbsoluteUrl)
         {
             EnsureEnabled();
-
-            if (Uri.TryCreate(routePathOrAbsoluteUrl, UriKind.Absolute, out var absoluteUri))
-            {
-                if (absoluteUri.Scheme != Uri.UriSchemeHttp && absoluteUri.Scheme != Uri.UriSchemeHttps)
-                {
-                    throw new InvalidOperationException($"{RedirectTargetPathEnvironmentVariableName} must use http or https when configured as an absolute URL.");
-                }
-
-                return absoluteUri.ToString();
-            }
-
             return ResolveAbsoluteUrl(routePathOrAbsoluteUrl);
         }
 
         public string ToRequestTarget(string routePathOrAbsoluteUrl)
         {
             EnsureEnabled();
-
-            if (Uri.TryCreate(routePathOrAbsoluteUrl, UriKind.Absolute, out var absoluteUri))
-            {
-                return absoluteUri.ToString();
-            }
-
             var normalizedRoutePath = NormalizeRoutePath(routePathOrAbsoluteUrl, nameof(routePathOrAbsoluteUrl));
             return normalizedRoutePath == StorefrontRoutes.Home
                 ? string.Empty
@@ -208,33 +191,6 @@ namespace BlazorShop.Tests.Presentation.Storefront
             }
 
             return statusCode;
-        }
-
-        private static string? ReadOptionalRouteOrAbsoluteUrl(Func<string, string?> getValue, string environmentVariableName, string defaultValue)
-        {
-            var rawValue = getValue(environmentVariableName);
-            if (rawValue is null)
-            {
-                return defaultValue;
-            }
-
-            if (string.IsNullOrWhiteSpace(rawValue))
-            {
-                return null;
-            }
-
-            var trimmedValue = rawValue.Trim();
-            if (Uri.TryCreate(trimmedValue, UriKind.Absolute, out var absoluteUri))
-            {
-                if (absoluteUri.Scheme != Uri.UriSchemeHttp && absoluteUri.Scheme != Uri.UriSchemeHttps)
-                {
-                    throw new InvalidOperationException($"{environmentVariableName} must use http or https when specified as an absolute URL.");
-                }
-
-                return absoluteUri.ToString();
-            }
-
-            return NormalizeRoutePath(trimmedValue, environmentVariableName);
         }
 
         private static string? ReadOptionalRoutePath(Func<string, string?> getValue, string environmentVariableName, string defaultValue)
@@ -304,19 +260,32 @@ namespace BlazorShop.Tests.Presentation.Storefront
                 throw new InvalidOperationException($"{environmentVariableName} must be a non-empty storefront route path.");
             }
 
-            if (Uri.TryCreate(trimmedValue, UriKind.Absolute, out _))
+            if (HasExplicitUriScheme(trimmedValue) || trimmedValue.StartsWith("//", StringComparison.Ordinal))
             {
                 throw new InvalidOperationException($"{environmentVariableName} must be a storefront route path, not an absolute URL.");
             }
 
             if (!trimmedValue.StartsWith("/", StringComparison.Ordinal))
             {
-                trimmedValue = $"/{trimmedValue}";
+                throw new InvalidOperationException($"{environmentVariableName} must begin with '/'.");
             }
 
             return trimmedValue.Length == 1
                 ? StorefrontRoutes.Home
                 : trimmedValue.TrimEnd('/');
+        }
+
+        private static bool HasExplicitUriScheme(string value)
+        {
+            var trimmedValue = value.Trim();
+            var colonIndex = trimmedValue.IndexOf(':');
+            if (colonIndex <= 0)
+            {
+                return false;
+            }
+
+            var firstPathSeparatorIndex = trimmedValue.IndexOfAny(['/', '?', '#']);
+            return firstPathSeparatorIndex < 0 || colonIndex < firstPathSeparatorIndex;
         }
     }
 }


### PR DESCRIPTION
Improve URL and path validation in test suite

Replaces Uri.TryCreate with custom scheme detection to better distinguish relative paths from absolute URLs and reject protocol-relative URLs. Enforces that route paths must start with '/', throwing exceptions if not. Only allows HTTP/HTTPS schemes for absolute URLs. Removes ReadOptionalRouteOrAbsoluteUrl and updates related logic to accept only route paths where required. Adds TryCreateHttpAbsoluteUri helpers and unifies path normalization and validation for clearer, more consistent error handling.