### PR TITLE
Add Node.js, npm, and Tailwind CSS build to Dockerfile

### DIFF
--- a/BlazorShop.Presentation/BlazorShop.Storefront/Dockerfile
+++ b/BlazorShop.Presentation/BlazorShop.Storefront/Dockerfile
@@ -4,6 +4,10 @@ ARG DOTNET_ASPNET_IMAGE=mcr.microsoft.com/dotnet/aspnet:10.0.6-noble
 FROM ${DOTNET_SDK_IMAGE} AS build
 WORKDIR /src
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY BlazorShop.Presentation/BlazorShop.Storefront/BlazorShop.Storefront.csproj BlazorShop.Presentation/BlazorShop.Storefront/
 COPY BlazorShop.Presentation/BlazorShop.Web.Shared/BlazorShop.Web.Shared.csproj BlazorShop.Presentation/BlazorShop.Web.Shared/
 COPY BlazorShop.Application/BlazorShop.Application.csproj BlazorShop.Application/
@@ -12,11 +16,23 @@ COPY BlazorShop.ServiceDefaults/BlazorShop.ServiceDefaults.csproj BlazorShop.Ser
 
 RUN dotnet restore BlazorShop.Presentation/BlazorShop.Storefront/BlazorShop.Storefront.csproj
 
+COPY BlazorShop.Presentation/BlazorShop.Web/package.json BlazorShop.Presentation/BlazorShop.Web/package.json
+COPY BlazorShop.Presentation/BlazorShop.Web/package-lock.json BlazorShop.Presentation/BlazorShop.Web/package-lock.json
+
 COPY BlazorShop.Presentation/BlazorShop.Storefront/ BlazorShop.Presentation/BlazorShop.Storefront/
+COPY BlazorShop.Presentation/BlazorShop.Web/ BlazorShop.Presentation/BlazorShop.Web/
 COPY BlazorShop.Presentation/BlazorShop.Web.Shared/ BlazorShop.Presentation/BlazorShop.Web.Shared/
 COPY BlazorShop.Application/ BlazorShop.Application/
 COPY BlazorShop.Domain/ BlazorShop.Domain/
 COPY BlazorShop.ServiceDefaults/ BlazorShop.ServiceDefaults/
+
+WORKDIR /src/BlazorShop.Presentation/BlazorShop.Web
+
+RUN rm -rf node_modules \
+    && npm ci \
+    && npx tailwindcss -c tailwind.config.js -i ./wwwroot/css/input.css -o ./wwwroot/css/site.css --minify
+
+WORKDIR /src
 
 RUN dotnet publish BlazorShop.Presentation/BlazorShop.Storefront/BlazorShop.Storefront.csproj \
     --configuration Release \


### PR DESCRIPTION
Add Node.js, npm, and Tailwind CSS build to Dockerfile

Updated Dockerfile to install Node.js and npm, copy frontend package files, install npm dependencies, and run Tailwind CSS to build and minify CSS assets for BlazorShop.Web during the Docker build process. Adjusted working directories to support these frontend build steps.