### PR TITLE
Use safe demo payment mode

### DIFF
--- a/BlazorShop.Application/Options/StripeOptions.cs
+++ b/BlazorShop.Application/Options/StripeOptions.cs
@@ -4,6 +4,8 @@ namespace BlazorShop.Application.Options
     {
         public const string SectionName = "Stripe";
 
+        public bool Enabled { get; set; }
+
         public string SecretKey { get; set; } = string.Empty;
 
         public string WebhookSecret { get; set; } = string.Empty;

--- a/BlazorShop.Application/Services/Payment/PaymentMethodService.cs
+++ b/BlazorShop.Application/Services/Payment/PaymentMethodService.cs
@@ -3,8 +3,11 @@
     using AutoMapper;
 
     using BlazorShop.Application.DTOs.Payment;
+    using BlazorShop.Application.Options;
     using BlazorShop.Application.Services.Contracts.Payment;
     using BlazorShop.Domain.Contracts.Payment;
+
+    using Microsoft.Extensions.Options;
 
     public class PaymentMethodService : IPaymentMethodService
     {
@@ -12,11 +15,16 @@
 
         private readonly IPaymentMethod _paymentMethod;
         private readonly IMapper _mapper;
+        private readonly StripeOptions _stripeOptions;
 
-        public PaymentMethodService(IPaymentMethod paymentMethod, IMapper mapper)
+        public PaymentMethodService(
+            IPaymentMethod paymentMethod,
+            IMapper mapper,
+            IOptions<StripeOptions> stripeOptions)
         {
             this._paymentMethod = paymentMethod;
             this._mapper = mapper;
+            this._stripeOptions = stripeOptions.Value;
         }
 
         public async Task<IEnumerable<GetPaymentMethod>> GetPaymentMethodsAsync()
@@ -30,6 +38,8 @@
 
             var supportedMethods = methods
                 .Where(method => !DisabledPaymentMethodNames.Contains(method.Name, StringComparer.OrdinalIgnoreCase))
+                .Where(method => this._stripeOptions.Enabled
+                    || !string.Equals(method.Name, "Credit Card", StringComparison.OrdinalIgnoreCase))
                 .ToList();
 
             if (supportedMethods.Count == 0)

--- a/BlazorShop.Presentation/BlazorShop.API/appsettings.json
+++ b/BlazorShop.Presentation/BlazorShop.API/appsettings.json
@@ -24,6 +24,7 @@
     "RequireConfirmedEmail": true
   },
   "Stripe": {
+    "Enabled": false,
     "SecretKey": "<set-in-user-secrets>",
     "WebhookSecret": "<set-in-user-secrets>"
   },

--- a/BlazorShop.Tests/Application/Services/Payment/PaymentMethodServiceTests.cs
+++ b/BlazorShop.Tests/Application/Services/Payment/PaymentMethodServiceTests.cs
@@ -6,9 +6,11 @@ namespace BlazorShop.Tests.Application.Services.Payment
     using System.Threading.Tasks;
     using AutoMapper;
     using BlazorShop.Application.DTOs.Payment;
+    using BlazorShop.Application.Options;
     using BlazorShop.Application.Services.Payment;
     using BlazorShop.Domain.Contracts.Payment;
     using BlazorShop.Domain.Entities.Payment;
+    using Microsoft.Extensions.Options;
     using Moq;
     using Xunit;
 
@@ -25,7 +27,8 @@ namespace BlazorShop.Tests.Application.Services.Payment
 
             _paymentMethodService = new PaymentMethodService(
                 _paymentMethodMock.Object,
-                _mapperMock.Object);
+                _mapperMock.Object,
+                Options.Create(new StripeOptions { Enabled = true }));
         }
 
         [Fact]
@@ -98,6 +101,41 @@ namespace BlazorShop.Tests.Application.Services.Payment
             // Assert
             Assert.Empty(result);
             _mapperMock.Verify(m => m.Map<IEnumerable<GetPaymentMethod>>(It.IsAny<IEnumerable<PaymentMethod>>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task GetPaymentMethodsAsync_ShouldHideCreditCard_WhenStripeIsDisabled()
+        {
+            // Arrange
+            var paymentMethods = new List<PaymentMethod>
+            {
+                new PaymentMethod { Id = Guid.NewGuid(), Name = "Credit Card" },
+                new PaymentMethod { Id = Guid.NewGuid(), Name = "Cash on Delivery" },
+                new PaymentMethod { Id = Guid.NewGuid(), Name = "Bank Transfer" }
+            };
+            var supportedMethods = paymentMethods.Where(paymentMethod => paymentMethod.Name != "Credit Card").ToList();
+            var mappedMethods = supportedMethods
+                .Select(paymentMethod => new GetPaymentMethod { Id = paymentMethod.Id, Name = paymentMethod.Name })
+                .ToList();
+            var paymentMethodService = new PaymentMethodService(
+                _paymentMethodMock.Object,
+                _mapperMock.Object,
+                Options.Create(new StripeOptions { Enabled = false }));
+
+            _paymentMethodMock
+                .Setup(pm => pm.GetPaymentMethodsAsync())
+                .ReturnsAsync(paymentMethods);
+            _mapperMock
+                .Setup(m => m.Map<IEnumerable<GetPaymentMethod>>(supportedMethods))
+                .Returns(mappedMethods);
+
+            // Act
+            var result = await paymentMethodService.GetPaymentMethodsAsync();
+
+            // Assert
+            Assert.DoesNotContain(result, paymentMethod => paymentMethod.Name == "Credit Card");
+            Assert.Contains(result, paymentMethod => paymentMethod.Name == "Cash on Delivery");
+            Assert.Contains(result, paymentMethod => paymentMethod.Name == "Bank Transfer");
         }
     }
 }

--- a/compose.production.yml
+++ b/compose.production.yml
@@ -28,8 +28,9 @@ services:
       ClientApp__BaseUrl: ${BLAZORSHOP_CLIENT_APP_BASE_URL:?BLAZORSHOP_CLIENT_APP_BASE_URL is required}
       Identity__RequireConfirmedAccount: ${BLAZORSHOP_REQUIRE_CONFIRMED_ACCOUNT:-true}
       Identity__RequireConfirmedEmail: ${BLAZORSHOP_REQUIRE_CONFIRMED_EMAIL:-true}
-      Stripe__SecretKey: ${BLAZORSHOP_STRIPE_SECRET_KEY}
-      Stripe__WebhookSecret: ${BLAZORSHOP_STRIPE_WEBHOOK_SECRET:?BLAZORSHOP_STRIPE_WEBHOOK_SECRET is required}
+      Stripe__Enabled: ${BLAZORSHOP_STRIPE_ENABLED:-false}
+      Stripe__SecretKey: "${BLAZORSHOP_STRIPE_SECRET_KEY:-}"
+      Stripe__WebhookSecret: "${BLAZORSHOP_STRIPE_WEBHOOK_SECRET:-}"
       EmailSettings__Enabled: ${BLAZORSHOP_EMAIL_ENABLED:-true}
       EmailSettings__From: "${BLAZORSHOP_EMAIL_FROM:-}"
       EmailSettings__DisplayName: ${BLAZORSHOP_EMAIL_DISPLAY_NAME:-BlazorShop}

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -81,6 +81,7 @@ Jwt__Audience=https://api.shop.example.com
 ClientApp__BaseUrl=https://account.shop.example.com
 Identity__RequireConfirmedAccount=true
 Identity__RequireConfirmedEmail=true
+Stripe__Enabled=false
 Stripe__SecretKey=<secret>
 Stripe__WebhookSecret=<secret>
 EmailSettings__Enabled=true
@@ -179,11 +180,11 @@ Required environment variables before startup:
 
 - `BLAZORSHOP_DB_PASSWORD`
 - `BLAZORSHOP_JWT_KEY`
-- `BLAZORSHOP_STRIPE_SECRET_KEY`
-- `BLAZORSHOP_STRIPE_WEBHOOK_SECRET`
 - `BLAZORSHOP_API_BASE_URL`
 - `BLAZORSHOP_CLIENT_APP_BASE_URL`
 - `BLAZORSHOP_STOREFRONT_BASE_URL`
+
+Card payments are disabled by default, which is appropriate for a demonstration deployment. Set `BLAZORSHOP_STRIPE_ENABLED=true` only when Stripe is intentionally enabled; in that case, `BLAZORSHOP_STRIPE_SECRET_KEY` and `BLAZORSHOP_STRIPE_WEBHOOK_SECRET` must also be populated from Stripe.
 
 When `BLAZORSHOP_EMAIL_ENABLED=true` (the default), these are also required by application startup validation:
 
@@ -446,8 +447,8 @@ The GitHub Actions workflow `ci` runs the `build-test` job, which already covers
 9. Verify that a browser preflight request from the public web origin succeeds against a public API endpoint.
 10. Verify that public traffic is throttled as expected while authenticated flows still work.
 11. Upload a test image and confirm it still exists after an API container restart.
-12. Register `https://<api-host>/api/stripe/webhook` in Stripe for `checkout.session.completed`, `checkout.session.async_payment_succeeded`, `checkout.session.async_payment_failed`, and `checkout.session.expired`; store its signing secret in `BLAZORSHOP_STRIPE_WEBHOOK_SECRET`.
-13. Complete a Stripe test checkout and verify that the pending order becomes `Paid` only after the signed webhook is received.
+12. If Stripe is enabled, register `https://<api-host>/api/stripe/webhook` for `checkout.session.completed`, `checkout.session.async_payment_succeeded`, `checkout.session.async_payment_failed`, and `checkout.session.expired`; store its signing secret in `BLAZORSHOP_STRIPE_WEBHOOK_SECRET`.
+13. If Stripe is enabled, complete a Stripe test checkout and verify that the pending order becomes `Paid` only after the signed webhook is received.
 
 ## GitHub Branch Protection
 

--- a/docs/production.appsettings.example.json
+++ b/docs/production.appsettings.example.json
@@ -15,6 +15,7 @@
     "RequireConfirmedEmail": true
   },
   "Stripe": {
+    "Enabled": false,
     "SecretKey": "<set-in-secret-store-or-env>",
     "WebhookSecret": "<set-in-secret-store-or-env>"
   },


### PR DESCRIPTION
## What changed

- added an explicit Stripe enable/disable option
- disabled Stripe by default for demo deployments
- hid Credit Card from the payment methods API when Stripe is disabled
- made Stripe secrets optional in Docker Compose while demo mode is active
- documented how to opt in to real Stripe payments

## Why

The public site is a demonstration store and should not request real card details or require a Stripe webhook secret. Cash on Delivery and Bank Transfer remain available for demonstrating checkout and order creation.

## Validation

- `dotnet test BlazorShop.sln --no-restore --configuration Release --artifacts-path .artifacts -warnaserror`
- 458 passed, 10 skipped, 0 failed
- production Docker Compose configuration validated without Stripe secrets
- deployed to the VPS as commit `9884096`
- storefront and account URLs return HTTP 200
- production payment methods API returns only Cash on Delivery and Bank Transfer
